### PR TITLE
Add guards for templates

### DIFF
--- a/packages/bundles/provider-kairos/build.yaml
+++ b/packages/bundles/provider-kairos/build.yaml
@@ -1,13 +1,14 @@
-{{ if eq .Values.init "systemd" }}
+{{ if .Values.init  }}
+  {{ if eq .Values.init "systemd" }}
 image: golang:1.18
 prelude:
 - apt-get update
 - apt-get install -y git
-{{ else }}
+  {{ else }}
 image: golang:1.18-alpine
 prelude:
 - apk add git
-{{ end }}
+  {{ end }}
 - git clone https://github.com/kairos-io/provider-kairos
 - |
     PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
@@ -17,3 +18,4 @@ steps:
 - cd provider-kairos && go build -o agent-provider-kairos
 - mv provider-kairos/agent-provider-kairos /system/providers/agent-provider-kairos
 - ln -s /system/providers/agent-provider-kairos /usr/bin/kairos
+{{ end }}

--- a/packages/kernels/build.yaml
+++ b/packages/kernels/build.yaml
@@ -7,8 +7,10 @@ steps:
 {{ if .Values.distribution }}
 {{if eq .Values.distribution "opensuse" }}
 - zypper in -y --no-recommends {{.Values.packages}}
-{{ if eq .Values.arch "arm64" }}
+{{ if .Values.arch }}
+  {{ if eq .Values.arch "arm64" }}
 - zypper in -y {{.Values.packages_arm}}
+  {{ end }}
 {{ end }}
 - zypper cc
 {{ if .Values.arch }}
@@ -28,10 +30,12 @@ steps:
 {{else if eq .Values.distribution "ubuntu" }}
 # Note for future issues with grub: https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1879558 https://github.com/rancher-sandbox/cOS-toolkit/pull/101#discussion_r621929109
 - apt-get update
-{{ if eq .Values.arch "arm64" }}
+{{ if .Values.arch }}
+  {{ if eq .Values.arch "arm64" }}
 - DEBIAN_FRONTEND=noninteractive apt-get install -y {{.Values.packages_arm}}
-{{ else }}
+  {{ else }}
 - DEBIAN_FRONTEND=noninteractive apt-get install -y {{.Values.packages}}
+  {{ end }}
 {{ end }}
 - apt-get clean
 - |

--- a/packages/static/grub-artifacts/build.yaml
+++ b/packages/static/grub-artifacts/build.yaml
@@ -2,15 +2,17 @@
 image: {{.Values.image}}
 
 {{if eq .Values.distribution "opensuse"}}
-{{ if eq .Values.arch "arm64" }}
+  {{ if .Values.arch }}
+    {{ if eq .Values.arch "arm64" }}
 prelude:
 - zypper in -y grub2-arm64-efi grub2
-{{ else if eq .Values.arch "arm" }}
+    {{ else if eq .Values.arch "arm" }}
 
-{{ else }}
+    {{ else }}
 prelude:
 - zypper in -y grub2-i386-pc grub2-x86_64-efi grub2
-{{ end }}
+    {{ end }}
+  {{end}}
 {{end}}
 
 steps:

--- a/packages/system/shim/build.yaml
+++ b/packages/system/shim/build.yaml
@@ -1,5 +1,6 @@
 # This is only for amd64
-{{ if eq .Values.arch "" }}
+{{ if .Values.arch }}
+  {{ if eq .Values.arch "" }}
 image: registry.opensuse.org/opensuse/leap:15.3
 
 prelude:
@@ -12,4 +13,5 @@ includes:
 excludes:
 # This is shipped by system/grub2-efi
 - usr/share/efi/.*/grub.efi
+  {{end}}
 {{end}}

--- a/packages/utils/operator-sdk/build.yaml
+++ b/packages/utils/operator-sdk/build.yaml
@@ -1,5 +1,6 @@
 # This is only for amd64
-{{ if eq .Values.arch "" }}
+{{ if .Values.arch }}
+  {{ if eq .Values.arch "" }}
 requires:
 - name: "toolchain-go"
   category: "development"
@@ -15,4 +16,5 @@ steps:
 - cd go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/  && git checkout v"${PACKAGE_VERSION}" -b build && make build && mv build/* /usr/bin/
 includes:
 - usr/bin/.*|usr/bin
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
If you try to build locally some issues will arise due the templating trying to access non existing values.

This patch guards those failures by first checking the the var exists before trying to get the value, avoiding panics.

Signed-off-by: Itxaka <itxaka.garcia@spectrocloud.com>