### PR TITLE
Fix system/grub2-efi package

### DIFF
--- a/packages/system/grub2-efi/build.yaml
+++ b/packages/system/grub2-efi/build.yaml
@@ -6,14 +6,14 @@ prelude:
 {{ if .Values.arch }}
   {{ if eq .Values.arch "arm64" }}
 steps:
-- zypper in -y grub2-arm64-efi shim-susesigned
+- zypper in -y grub2-arm64-efi shim
 includes:
 - usr/share/grub2/arm64-efi/
 - usr/share/efi/.*/*.efi
 - usr/share/efi/.*/*.der
   {{else}}
 steps:
-- zypper in -y grub2-x86_64-efi shim-susesigned
+- zypper in -y grub2-x86_64-efi shim
 includes:
 - usr/share/grub2/x86_64-efi/
 - usr/share/efi/.*/*.efi

--- a/packages/system/grub2-efi/definition.yaml
+++ b/packages/system/grub2-efi/definition.yaml
@@ -1,6 +1,6 @@
 name: "grub2-efi"
 category: "system"
-version: "2.06-150402"
+version: "2.06-150403"
 pversion: "2.06-150400.12.2"
 license: "GPL-3.0-or-later"
 arch: "x86_64"


### PR DESCRIPTION
Files in the shim package are already signed AND thye provide more efi tools, like the mokmanager or a fallback efi binary