### PR TITLE
Upgrade grub on livecd

### DIFF
--- a/packages/livecd/grub2/build.yaml
+++ b/packages/livecd/grub2/build.yaml
@@ -1,4 +1,4 @@
-image: "opensuse/leap:15.3"
+image: "opensuse/leap:15.4"
 
 prelude:
 - zypper in -y git


### PR DESCRIPTION
Update to latest leap to get 2.06 like in the main installation. Wanted to switch to tumbleweed but the fact that we mix x86 and arm in this package makes it not possible since tumbleweed doesn't allow to install the package of a different arch