### PR TITLE
Fix kairos-agent call for upgrade

### DIFF
--- a/packages/system/suc-upgrade/definition.yaml
+++ b/packages/system/suc-upgrade/definition.yaml
@@ -1,3 +1,3 @@
 name: "suc-upgrade"
 category: "system"
-version: "0.2.0"
+version: "0.2.1"

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -12,6 +12,6 @@ fi
 
 mount --rbind $HOST_DIR/dev /dev
 mount --rbind $HOST_DIR/run /run
-kairos-agent upgrade --directory /
+kairos-agent upgrade --source dir:/
 nsenter -i -m -t 1 -- reboot
 exit 1


### PR DESCRIPTION
because the command line arguments have now changed

This should fix the provider-kairos e2e tests