### PR TITLE
Build fips packages with go 1.19.10

### DIFF
--- a/packages/system/immucore/build.yaml
+++ b/packages/system/immucore/build.yaml
@@ -1,8 +1,14 @@
+{{if eq .Values.category "fips" }}
+requires:
+  - name: "toolchain-go-ubuntu"
+    category: "fips"
+    version: ">=0"
+{{else}}
 requires:
   - name: "toolchain-go-ubuntu"
     category: "development"
     version: ">=0"
-
+{{end}}
 prelude:
 {{if eq .Values.category "fips" }}
   - apt-get update && apt-get install gcc

--- a/packages/system/kairos-agent/build.yaml
+++ b/packages/system/kairos-agent/build.yaml
@@ -1,8 +1,18 @@
+{{if eq .Values.category "fips" }}
+requires:
+  - name: "toolchain-go-ubuntu"
+    category: "fips"
+    version: ">=0"
+{{else}}
 requires:
   - name: "toolchain-go-ubuntu"
     category: "development"
     version: ">=0"
-
+{{end}}
+prelude:
+  - apt-get update && apt-get install -y npm gcc
+  - mkdir /go/src/github.com/${GITHUB_ORG}/ -p
+  - cd /go/src/github.com/${GITHUB_ORG}/ && git clone --branch v${PACKAGE_VERSION} https://github.com/${GITHUB_ORG}/{{ .Values.name }}.git
 env:
   - GITHUB_ORG={{ ( index .Values.labels "github.owner" ) }}
   - HUGO_VERSION=0.110.0
@@ -22,10 +32,6 @@ copy:
       version: ">=0"
     source: "/usr/share/doc/kairos"
     destination: "/kairos-docs/"
-prelude:
-  - apt-get update && apt-get install -y npm gcc
-  - mkdir /go/src/github.com/${GITHUB_ORG}/ -p
-  - cd /go/src/github.com/${GITHUB_ORG}/ && git clone --branch v${PACKAGE_VERSION} https://github.com/${GITHUB_ORG}/{{ .Values.name }}.git
 steps:
   # Docs for webui, copy them from the package
   - mkdir -p /go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/internal/webui/public/local

--- a/packages/system/kcrypt-challenger/build.yaml
+++ b/packages/system/kcrypt-challenger/build.yaml
@@ -1,7 +1,14 @@
+{{if eq .Values.category "fips" }}
 requires:
-- name: "toolchain-go-ubuntu"
-  category: "development"
-  version: ">=0"
+  - name: "toolchain-go-ubuntu"
+    category: "fips"
+    version: ">=0"
+{{else}}
+requires:
+  - name: "toolchain-go-ubuntu"
+    category: "development"
+    version: ">=0"
+{{end}}
 prelude:
 {{if eq .Values.category "fips" }}
   - apt-get update && apt-get install -y gcc

--- a/packages/system/kcrypt/build.yaml
+++ b/packages/system/kcrypt/build.yaml
@@ -1,7 +1,14 @@
+{{if eq .Values.category "fips" }}
 requires:
-- name: "toolchain-go-ubuntu"
-  category: "development"
-  version: ">=0"
+  - name: "toolchain-go-ubuntu"
+    category: "fips"
+    version: ">=0"
+{{else}}
+requires:
+  - name: "toolchain-go-ubuntu"
+    category: "development"
+    version: ">=0"
+{{end}}
 prelude:
 {{if eq .Values.category "fips" }}
   - apt-get update && apt-get install -y gcc

--- a/packages/toolchain-go/collection.yaml
+++ b/packages/toolchain-go/collection.yaml
@@ -1,25 +1,49 @@
 packages:
-- name: toolchain-go
-  category: development
-  variant: "alpine"
-  version: "1.20.2"
-  tag: "1.20.2"
-  hidden: true
-- name: toolchain-go-ubuntu
-  variant: ""
-  category: development
-  version: "1.20.2"
-  tag: "1.20.2"
-  hidden: true
-- name: toolchain-go
-  category: development
-  variant: "alpine"
-  version: "1.20.2"
-  tag: "1.20.2"
-  hidden: true
-- name: toolchain-go-ubuntu
-  variant: ""
-  category: development
-  version: "1.20.2"
-  tag: "1.20.2"
-  hidden: true
+  - name: toolchain-go
+    category: development
+    variant: "alpine"
+    version: "1.20.2"
+    tag: "1.20.2"
+    hidden: true
+  - name: toolchain-go-ubuntu
+    variant: ""
+    category: development
+    version: "1.20.2"
+    tag: "1.20.2"
+    hidden: true
+  - name: toolchain-go
+    category: development
+    variant: "alpine"
+    version: "1.20.2"
+    tag: "1.20.2"
+    hidden: true
+  - name: toolchain-go-ubuntu
+    variant: ""
+    category: development
+    version: "1.20.2"
+    tag: "1.20.2"
+    hidden: true
+  - name: toolchain-go
+    category: fips
+    variant: "alpine"
+    version: "1.19.10"
+    tag: "1.19.10"
+    hidden: true
+  - name: toolchain-go-ubuntu
+    variant: ""
+    category: fips
+    version: "1.19.10"
+    tag: "1.19.10"
+    hidden: true
+  - name: toolchain-go
+    category: fips
+    variant: "alpine"
+    version: "1.19.10"
+    tag: "1.19.10"
+    hidden: true
+  - name: toolchain-go-ubuntu
+    variant: ""
+    category: fips
+    version: "1.19.10"
+    tag: "1.19.10"
+    hidden: true


### PR DESCRIPTION
Go 1.19.10 is the verified fips version from our side so we need to build those packages with that specific version.

This patch adds a go tollchain fips specific that is pinned to the know verified fips go version and that its used to build the fips verified go packages

Fixes: https://github.com/kairos-io/kairos/issues/1498