### PR TITLE
Do a different check for fips on immucore

### DIFF
--- a/packages/system/immucore/build.yaml
+++ b/packages/system/immucore/build.yaml
@@ -32,7 +32,7 @@ steps:
     cd go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/ && git checkout v"${PACKAGE_VERSION}" -b build && go build -o {{ .Values.name }} -ldflags="${LDFLAGS}" && mv {{.Values.name}} /usr/bin/
   - chmod +x /usr/bin/{{.Values.name}}
 {{if eq .Values.category "fips" }}
-  - go tool nm /usr/bin/{{.Values.name}} | grep -i "FIPS_mode"
+  - /usr/bin/{{.Values.name}} version 2>&1 >/dev/null | grep -i boringcrypto
 {{end}}
 includes:
   - /usr/bin/{{.Values.name}}


### PR DESCRIPTION
It appears that immucore is not using the ssl libs anywhere so we cannot check the final binary for the FIPS string.

Thankfully immucore has a version command that prints the version and the go version used to compile it, so we can grep for boringcrypto in there to know if the go version was build with boringcrypto.

We should probably use the same version command everywhere so its easier to show the go version that our binaries were compiled with