### PR TITLE
Update cos-setup-network.service to look like the other services

### DIFF
--- a/packages/system/init-svc/systemd/cos-setup-network.service
+++ b/packages/system/init-svc/systemd/cos-setup-network.service
@@ -3,14 +3,9 @@ Description=cOS setup after network
 After=network-online.target
 
 [Service]
-Nice=19
-IOSchedulingClass=2
-IOSchedulingPriority=7
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent run-stage network
-TimeoutStopSec=180
-KillMode=process
-KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/system/init-svc/systemd/definition.yaml
+++ b/packages/system/init-svc/systemd/definition.yaml
@@ -1,3 +1,3 @@
 name: systemd
 category: init-svc
-version: 0.7.0
+version: 0.8.0


### PR DESCRIPTION
Currently the network service is not kept as alive like the other and has some other configs in there which dont make much sense.

This patch just makes it equal to the rest of the other oneshot services