### PR TITLE
Skip the fips check under arm64

### DIFF
--- a/packages/system/kairos-agent/build.yaml
+++ b/packages/system/kairos-agent/build.yaml
@@ -45,7 +45,11 @@ steps:
     go build -o /usr/bin/{{ .Values.name }} -ldflags="${LDFLAGS}"
   - chmod +x /usr/bin/{{.Values.name}}
 {{if eq .Values.category "fips" }}
+  {{ if .Values.arch }}
+    {{ if eq .Values.arch "amd64" }}
   - go tool nm /usr/bin/{{.Values.name}} | grep -i "FIPS_mode"
+    {{end}}
+  {{end}}
 {{end}}
 includes:
   - /usr/bin/{{.Values.name}}

--- a/packages/system/kcrypt-challenger/build.yaml
+++ b/packages/system/kcrypt-challenger/build.yaml
@@ -37,7 +37,11 @@ steps:
     cd go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/ && go build -o {{ .Values.binary_name }} ./cmd/discovery/main.go && mv {{ .Values.binary_name }} /system/discovery
   - chmod +x /system/discovery/{{ .Values.binary_name }}
 {{if eq .Values.category "fips" }}
+  {{ if .Values.arch }}
+    {{ if eq .Values.arch "amd64" }}
   - go tool nm /system/discovery/{{ .Values.binary_name }} | grep -i "FIPS_mode"
+    {{end}}
+  {{end}}
 {{end}}
 includes:
   - /system/discovery/{{ .Values.binary_name }}

--- a/packages/system/kcrypt/build.yaml
+++ b/packages/system/kcrypt/build.yaml
@@ -32,7 +32,11 @@ steps:
     cd go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/ && git checkout v"${PACKAGE_VERSION}" -b build && go build -ldflags="${LDFLAGS}" && mv {{.Values.name}} /usr/bin/
   - chmod +x /usr/bin/{{.Values.name}}
 {{if eq .Values.category "fips" }}
+  {{ if .Values.arch }}
+    {{ if eq .Values.arch "amd64" }}
   - go tool nm /usr/bin/{{.Values.name}} | grep -i "FIPS_mode"
+    {{end}}
+  {{end}}
 {{end}}
 includes:
   - /usr/bin/{{.Values.name}}


### PR DESCRIPTION
For some reason the output of the strings do not work properly under arm64. Skip it for now until we implement it the same way as immucore does