### PR TITLE
Fix default grub entry name to kairos

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.3"
+version: "0.4"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -38,7 +38,7 @@ fi
 if [ "${default_menu_entry}" ]; then
   set display_name="${default_menu_entry}"
 else
-  set display_name="cOS"
+  set display_name="Kairos"
 fi
 
 ## Set a default fallback if set


### PR DESCRIPTION
As we dont ship the elemental config by default, this should fallback into a sane value so we dont have to have extra configs lying around.