### PR TITLE
Add older version of kairos-agent v2.1.12

### DIFF
--- a/packages/system/kairos-agent/collection.yaml
+++ b/packages/system/kairos-agent/collection.yaml
@@ -9,7 +9,19 @@ packages:
     uri:
       - https://github.com/kairos-io/kairos-agent
     license: "Apache License v2"
-    description: "Lyfecycle agent for kairos"
+    description: "Lifecycle agent for kairos"
+  # Only needed for backporting kairos to v2.3.1
+  # https://github.com/kairos-io/kairos-agent/releases/tag/v2.1.12
+  - name: "kairos-agent"
+    category: "system"
+    version: "2.1.12"
+    labels:
+      github.repo: "kairos-agent"
+      github.owner: "kairos-io"
+    uri:
+      - https://github.com/kairos-io/kairos-agent
+    license: "Apache License v2"
+    description: "Lifecycle agent for kairos"
   - name: "kairos-agent"
     category: "fips"
     version: "2.2.0"
@@ -20,7 +32,7 @@ packages:
     uri:
       - https://github.com/kairos-io/kairos-agent
     license: "Apache License v2"
-    description: "Lyfecycle agent for kairos"
+    description: "Lifecycle agent for kairos"
   - name: "kairos-agent"
     category: "fips-static"
     ldflags: "-linkmode external -extldflags -static"
@@ -32,4 +44,4 @@ packages:
     uri:
       - https://github.com/kairos-io/kairos-agent
     license: "Apache License v2"
-    description: "Lyfecycle agent for kairos"
+    description: "Lifecycle agent for kairos"


### PR DESCRIPTION
This package is only needed temporarily so the image gets built with it