### PR TITLE
Test for squashfs recovery

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.4"
+version: "0.5"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -81,13 +81,13 @@ menuentry "${display_name} (fallback)" --id fallback {
 }
 
 menuentry "${display_name} recovery" --id recovery {
-  if search --no-floppy --file /cOS/recovery.squashfs ; then
+  search --no-floppy --label --set=root COS_RECOVERY
+  if [ test -s /cOS/recovery.squashfs ]; then
     set img=/cOS/recovery.squashfs
     set recoverylabel=COS_RECOVERY
   else
     set img=/cOS/recovery.img
   fi
-  search --no-floppy --label --set=root COS_RECOVERY
   set label=COS_SYSTEM
   loopback loop0 /$img
   set root=($root)


### PR DESCRIPTION
Instead of bindly doing a search which results in a error if recovery is not squash, just do a test to see if the file exit and set the parameters based on that

This should stop that ugly error message on recovery grub menu selection