### PR TITLE
fix: do not overlay mount persistent in recovery mode

### DIFF
--- a/packages/bundles/kairos-overlay-files/files/system/oem/12_nvidia.yaml
+++ b/packages/bundles/kairos-overlay-files/files/system/oem/12_nvidia.yaml
@@ -50,7 +50,8 @@ stages:
           ###       Usually this is not the case as there is no need of subtrees, but due to how overlayfs work the workdir and uppermount needs to be in the same filesystem.
           stages:
             initramfs.before:
-            - commands:
+            - if: '[ ! -f "/run/cos/recovery_mode" ]'
+              commands:
               - umount /usr/local
               - |
                  mkdir -p /run/mount/persistent && \


### PR DESCRIPTION
Potential fix for: https://github.com/kairos-io/kairos/issues/1723

In orin, we unify in a single overlay `/usr/local` from the image and COS_PERSISTENT. This creates a new mountpoint that gets in the way of running the recovery. Since this is only needed (the transparent mount) when running the workload - this PR disables the overlay mounting during `reset`.

I'm not able to test it for now as it seems upgrading the recovery is broken (https://github.com/kairos-io/kairos/issues/1751 ) - and I have to re-flash the board again as other attempts seems to have nuked my drive.