### PR TITLE
Update building of docs

### DIFF
--- a/packages/static/kairos-docs/build.yaml
+++ b/packages/static/kairos-docs/build.yaml
@@ -3,7 +3,7 @@ env:
   - GITHUB_ORG={{ ( index .Values.labels "github.owner" ) }}
   - HUGO_VERSION=0.110.0
 prelude:
-  - zypper ref && zypper in -y git wget tar nodejs-default gzip npm
+  - zypper ref && zypper in -y git wget tar nodejs-default gzip npm go
   - mkdir /go/src/github.com/${GITHUB_ORG}/ -p
   - cd /go/src/github.com/${GITHUB_ORG}/ && git clone https://github.com/${GITHUB_ORG}/{{ .Values.name }}.git
 steps:
@@ -15,6 +15,7 @@ steps:
     chmod +x hugo && \
     mv hugo /usr/bin && \
     cd /go/src/github.com/${GITHUB_ORG}/kairos-docs && \
-    npm install autoprefixer postcss-cli postcss \
+    npm install autoprefixer postcss-cli postcss && \
+    /usr/bin/hugo mod get && \
     HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "/usr/share/doc/kairos"
 package_dir: "/usr/share/doc/kairos"

--- a/packages/static/kairos-docs/build.yaml
+++ b/packages/static/kairos-docs/build.yaml
@@ -15,6 +15,6 @@ steps:
     chmod +x hugo && \
     mv hugo /usr/bin && \
     cd /go/src/github.com/${GITHUB_ORG}/kairos-docs && \
-    npm install --save-dev autoprefixer postcss-cli postcss
+    npm install --save-dev autoprefixer postcss-cli postcss \
     HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "/usr/share/doc/kairos"
 package_dir: "/usr/share/doc/kairos"

--- a/packages/static/kairos-docs/build.yaml
+++ b/packages/static/kairos-docs/build.yaml
@@ -15,7 +15,6 @@ steps:
     chmod +x hugo && \
     mv hugo /usr/bin && \
     cd /go/src/github.com/${GITHUB_ORG}/kairos-docs && \
-    npm install postcss-cli && \
-    npm run prepare && \
+    npm install --save-dev autoprefixer postcss-cli postcss
     HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "/usr/share/doc/kairos"
 package_dir: "/usr/share/doc/kairos"

--- a/packages/static/kairos-docs/build.yaml
+++ b/packages/static/kairos-docs/build.yaml
@@ -15,6 +15,6 @@ steps:
     chmod +x hugo && \
     mv hugo /usr/bin && \
     cd /go/src/github.com/${GITHUB_ORG}/kairos-docs && \
-    npm install --save-dev autoprefixer postcss-cli postcss \
+    npm install autoprefixer postcss-cli postcss \
     HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "/usr/share/doc/kairos"
 package_dir: "/usr/share/doc/kairos"

--- a/packages/static/kairos-docs/definition.yaml
+++ b/packages/static/kairos-docs/definition.yaml
@@ -1,6 +1,6 @@
 name: "kairos-docs"
 category: "static"
-version: "2.1.0"
+version: "2.1.1"
 arch: "amd64"
 labels:
   github.repo: "kairos-docs"


### PR DESCRIPTION
This was an issue because the package is downloading latest instead of a tag and the latest docs switched to using go modules instead of git submodules 