### PR TITLE
Set default kernel/initramfs vars in the generic grub.cfg

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.6"
+version: "0.7"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -1,5 +1,10 @@
 set timeout=10
 
+# set default values for kernel, initramfs
+# Other files can still override this
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd
+
 # Load custom env file
 set env_file="/grubenv"
 search --no-floppy --file --set=env_blk "${env_file}"


### PR DESCRIPTION
You can still override them via the usual bootargs.cfg in your distro, but it would be good to have the defaults already int he file in case we cant load the bootargs file or its missing, it has sane defaults