### PR TITLE
Split k3s package in 2 (one for openrc, one for systemd)

### DIFF
--- a/packages/k8s/k3s-openrc/build.yaml
+++ b/packages/k8s/k3s-openrc/build.yaml
@@ -1,0 +1,32 @@
+requires:
+- name: "toolchain-go"
+  category: "development"
+  version: ">=0"
+env:
+  - INSTALL_K3S_BIN_DIR="/usr/bin"
+  - INSTALL_K3S_SELINUX_WARN=true
+  - INSTALL_K3S_SKIP_START="true"
+  - INSTALL_K3S_SKIP_ENABLE="true"
+  - INSTALL_K3S_SKIP_SELINUX_RPM="true"
+  # Remove any possible "+N" from the end of the version. We only bump that to
+  # avoid overwritting existing images when we want the package to be rebuilt.
+  - INSTALL_K3S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k3s1
+  {{$arch:=(default "amd64" .Values.arch)}}
+  {{ if eq $arch "arm" }}
+  - ARCH=arm64
+  {{ else }}
+  - ARCH={{ $arch }}
+  {{ end }}
+steps:
+  - curl -sfL https://get.k3s.io > installer.sh
+  # Let the installer script install service files for openrc:
+  # https://github.com/k3s-io/k3s/blob/36645e7311e9bdbbf2adb79ecd8bd68556bc86f6/install.sh#L114-L122
+  - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
+  - bash installer.sh
+  - rm -rf installer.sh
+  - chmod +x /usr/bin/{{.Values.name}}
+
+includes:
+- ^/usr/bin/{{.Values.name}}
+- ^/etc/init.d/$
+- ^/etc/init.d/k3s.*

--- a/packages/k8s/k3s-openrc/collection.yaml
+++ b/packages/k8s/k3s-openrc/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: k3s
     category: k8s
-    version: "1.25.11+1"
+    version: "1.25.11"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -13,7 +13,7 @@ packages:
 
   - name: k3s
     category: k8s
-    version: "1.26.6+1"
+    version: "1.26.6"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -25,7 +25,7 @@ packages:
 
   - name: k3s
     category: k8s
-    version: "1.27.3+1"
+    version: "1.27.3"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"

--- a/packages/k8s/k3s-systemd/build.yaml
+++ b/packages/k8s/k3s-systemd/build.yaml
@@ -19,27 +19,15 @@ env:
   {{ end }}
 steps:
   - curl -sfL https://get.k3s.io > installer.sh
-  # Let the installer script install service files both for openrc and systemd:
+  # Let the installer script install service files for systemd:
   # https://github.com/k3s-io/k3s/blob/36645e7311e9bdbbf2adb79ecd8bd68556bc86f6/install.sh#L114-L122
   - touch /bin/systemctl && chmod +x /bin/systemctl
   - mkdir -p /etc/systemd/system/
   - bash installer.sh
   - bash installer.sh agent
-  # Save the service files elsewhere because the next run will delete them
-  - mkdir -p /service-files && cp /etc/systemd/system/k3s*.service /service-files/
-  # Run again to create the openrc service files
-  - rm /bin/systemctl
-  - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
-  - bash installer.sh
-  - rm -rf installer.sh
-  - chmod +x /usr/bin/{{.Values.name}}
-  # Put systemd service files back in place
-  - mv /service-files/* /etc/systemd/system/
 
 includes:
 - ^/usr/bin/{{.Values.name}}
 - ^/etc/systemd$
 - ^/etc/systemd/system$
 - ^/etc/systemd/system/k3s.*service$
-- ^/etc/init.d/$
-- ^/etc/init.d/k3s.*

--- a/packages/k8s/k3s-systemd/collection.yaml
+++ b/packages/k8s/k3s-systemd/collection.yaml
@@ -1,0 +1,36 @@
+packages:
+  - name: k3s
+    category: k8s
+    version: "1.25.11"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+
+  - name: k3s
+    category: k8s
+    version: "1.26.6"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+
+  - name: k3s
+    category: k8s
+    version: "1.27.3"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "


### PR DESCRIPTION
because having all service files in places, confuses systemd because of the sysv compatibility feature.

Part of: https://github.com/kairos-io/kairos/issues/1797