### PR TITLE
Copy the symlink of the openrc enabled service

### DIFF
--- a/packages/k8s/k3s/build.yaml
+++ b/packages/k8s/k3s/build.yaml
@@ -37,6 +37,7 @@ includes:
 {{ if eq .Values.name "k3s-openrc" }}
 - ^/etc/init.d/$
 - ^/etc/init.d/k3s.*
+- ^/etc/runlevels/$
 {{ else }}
 - ^/etc/systemd$
 - ^/etc/systemd/system$


### PR DESCRIPTION
because k3s is not enabled in alpine otherwise