### PR TITLE
Bump k3s systemd package versions too

### DIFF
--- a/packages/k8s/k3s/build.yaml
+++ b/packages/k8s/k3s/build.yaml
@@ -38,7 +38,7 @@ includes:
 - ^/etc/init.d/$
 - ^/etc/init.d/k3s.*
 - ^/etc/rancher/$
-- ^/etc/rancher/k3s/$
+- ^/etc/rancher/k3s$
 {{ else }}
 - ^/etc/systemd$
 - ^/etc/systemd/system$

--- a/packages/k8s/k3s/collection.yaml
+++ b/packages/k8s/k3s/collection.yaml
@@ -37,7 +37,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.25.11"
+    version: "1.25.11+1"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -49,7 +49,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.26.6"
+    version: "1.26.6+1"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -61,7 +61,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.27.3"
+    version: "1.27.3+1"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"

--- a/packages/k8s/k3s/collection.yaml
+++ b/packages/k8s/k3s/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: k3s-openrc
     category: k8s
-    version: "1.25.11+1"
+    version: "1.25.11+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -13,7 +13,7 @@ packages:
 
   - name: k3s-openrc
     category: k8s
-    version: "1.26.6+1"
+    version: "1.26.6+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -25,7 +25,7 @@ packages:
 
   - name: k3s-openrc
     category: k8s
-    version: "1.27.3+1"
+    version: "1.27.3+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -37,7 +37,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.25.11+1"
+    version: "1.25.11+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -49,7 +49,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.26.6+1"
+    version: "1.26.6+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -61,7 +61,7 @@ packages:
 
   - name: k3s-systemd
     category: k8s
-    version: "1.27.3+1"
+    version: "1.27.3+2"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"


### PR DESCRIPTION
It's not needed but that's the quickest fix for the fact that our pipelines assume both packages (openrc and systemd) have the same versions:

https://github.com/kairos-io/kairos/commit/b8b6e8713073b8342f0fbe14da8f3096cef4f62a