### PR TITLE
Set proper flags for reset service

### DIFF
--- a/packages/bundles/kairos-overlay-files/collection.yaml
+++ b/packages/bundles/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "bundles"
-    version: "1.0.5"
+    version: "1.0.6"

--- a/packages/bundles/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
+++ b/packages/bundles/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
@@ -8,6 +8,6 @@ StandardOutput=tty
 LimitNOFILE=49152
 TTYPath=/dev/tty1
 RemainAfterExit=yes
-ExecStart=/usr/bin/kairos-agent reset
+ExecStart=/usr/bin/kairos-agent reset --unattended --reboot
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Its supposed to be unattended and reboot afterwards and those are now new flags under the agent to not trigger them from a normal manual reset