### PR TITLE
Add /var/lib/extensions to persistent paths

### DIFF
--- a/packages/bundles/kairos-overlay-files/collection.yaml
+++ b/packages/bundles/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "bundles"
-    version: "1.0.6"
+    version: "1.0.7"

--- a/packages/bundles/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/bundles/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -39,6 +39,7 @@ stages:
           /usr/libexec
           /var/log
           /var/lib/containerd
+          /var/lib/extensions
           /var/lib/rancher
           /var/lib/kubelet
           /var/lib/snapd


### PR DESCRIPTION
because that's the proper place to put systemd-sysext extensions now:

https://www.freedesktop.org/software/systemd/man/systemd-sysext.html

Part of: https://github.com/kairos-io/kairos/issues/1821