### PR TITLE
Drop gfxterm

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.7"
+version: "0.8"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -53,14 +53,10 @@ else
   set fallback="0 1 2"
 fi
 
-set gfxmode=auto
-set gfxpayload=keep
 insmod all_video
-insmod gfxterm
 insmod loopback
 insmod squash4
 insmod serial
-terminal_output --append gfxterm
 loadfont unicode
 
 menuentry "${display_name}" --id cos {


### PR DESCRIPTION
Unless we really configure it for the lower common denominator is proving to be a pita.
Duplicated terminal outputs, wrong videomodes, and now out of memory when used in 4k devices.

This just drops the gfxterminal for now to stay with a text terminal for grub