### PR TITLE
Make kairos-sysext be generic enough to include on all flavors

### DIFF
--- a/packages/dracut/sysext/build.yaml
+++ b/packages/dracut/sysext/build.yaml
@@ -1,6 +1,7 @@
 image: alpine
 package_dir: "/package"
 steps:
-- mkdir -p /package/etc/systemd/network
 - mkdir -p /package/etc/dracut.conf.d
-- cp -rfv conf/* /package/etc/dracut.conf.d
+- mkdir -p /package/usr/lib/dracut/modules.d
+- cp files/90-kairos-sysext.conf /package/etc/dracut.conf.d/90-kairos-sysext.conf
+- cp -r files/90kairos-sysext /package/usr/lib/dracut/modules.d/90kairos-sysext

--- a/packages/dracut/sysext/collection.yaml
+++ b/packages/dracut/sysext/collection.yaml
@@ -1,4 +1,4 @@
 packages:
-- name: "sysext"
+- name: "kairos-sysext"
   category: "dracut"
-  version: "0.9"
+  version: "1.0.0"

--- a/packages/dracut/sysext/conf/90-kairos-sysext.conf
+++ b/packages/dracut/sysext/conf/90-kairos-sysext.conf
@@ -1,1 +1,0 @@
-add_dracutmodules+=" systemd-sysext "

--- a/packages/dracut/sysext/files/90-kairos-sysext.conf
+++ b/packages/dracut/sysext/files/90-kairos-sysext.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" kairos-sysext "

--- a/packages/dracut/sysext/files/90kairos-sysext/module-setup.sh
+++ b/packages/dracut/sysext/files/90kairos-sysext/module-setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This module tries to add systemd-sysext module to the initramfs if its in the system, otherwise it does nothing
+
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    # If the binary(s) requirements are not fulfilled the module can't be installed.
+    require_binaries systemd-sysext || return 1
+    # Check if the module files exists
+    # This is not normal but on ubuntu-22 the binary for sysext exists but the dracut module doesnt, so we
+    # need to do further checks before including it otherwise it will fail to build the initrd
+    files=( "${dracutbasedir}"/modules.d/??systemd-sysext )
+    [ "${#files[@]}" -ge 2 ] && return 1
+    if [ -d "${files[0]}" ]; then
+        echo "systemd-sysext"
+        return 0
+    else
+        dinfo "module 'systemd-sysext' will not be installed, because module dir could not be found!"
+    fi
+    return 1
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    return 0
+}


### PR DESCRIPTION
It will not install the systemd-sysext package if the binary is not there