### PR TITLE
Improve alpine initrd

### DIFF
--- a/packages/alpine/build.yaml
+++ b/packages/alpine/build.yaml
@@ -10,12 +10,6 @@ copy:
       version: ">=0"
     source: "/usr/bin/immucore"
     destination: "/usr/bin/immucore"
-  - package:
-      category: "system"
-      name: "kairos-agent"
-      version: ">=0"
-    source: "/usr/bin/kairos-agent"
-    destination: "/usr/bin/kairos-agent"
 package_dir: "/package"
 prelude:
   - apk update
@@ -28,6 +22,7 @@ steps:
   - cp -rfv /lib/modules/* /package/lib/modules
   # generate initramfs
   - cp files/immucore.files /etc/mkinitfs/features.d/immucore.files
+  - cp files/tpm.modules /etc/mkinitfs/features.d/tpm.modules
   - kernel=$(ls /lib/modules | head -n1) && mkinitfs -o /package/boot/initrd -i files/initramfs-init -c files/mkinitfs.conf $kernel
     {{end}}
   {{end}}
@@ -60,7 +55,8 @@ steps:
   - cp -rfv /lib/modules/* /package/lib/modules
   # generate initramfs
   - cp files/immucore.files /etc/mkinitfs/features.d/immucore.files
+  - cp files/tpm.modules /etc/mkinitfs/features.d/tpm.modules
   - kernel=$(ls /lib/modules | head -n1) && mkinitfs -o /package/boot/initrd -i files/initramfs-init -c files/mkinitfs.conf $kernel
-  {{end}}
+{{end}}
 
 

--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "alpine"
     category: "distro-kernel"
-    version: "6.1.56"
+    version: "6.1.56+1"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"
@@ -14,7 +14,7 @@ packages:
       package.version: "6.1.56"
   - name: "alpine-rpi"
     category: "distro-kernel"
-    version: "6.1.55"
+    version: "6.1.55+1"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"

--- a/packages/alpine/files/initramfs-init
+++ b/packages/alpine/files/initramfs-init
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=3.8.0-kairos1
+VERSION=3.8.1-kairos1
 INIT=/sbin/init
 sysroot="$ROOT"/sysroot
 
@@ -65,17 +65,22 @@ list_console_devices() {
 	done
 }
 
-detect_serial_console() {
+detect_serial_consoles() {
 	local n=$(awk '$7 ~ /CTS/ || $7 ~ /DSR/ { print $1 }' "$ROOT"/proc/tty/driver/serial 2>/dev/null)
 	if [ -n "$n" ]; then
 		echo ttyS${n%:}
 	fi
+	for i in "$ROOT"/sys/class/tty/*; do
+    if [ -e "$i"/device ]; then
+      echo ${i##*/}
+    fi
+  done
 }
 
 setup_inittab_console() {
 	term=vt100
 	# Inquire the kernel for list of console= devices
-	consoles="$(for c in console $(detect_serial_console); do list_console_devices $c; done)"
+	consoles="$(for c in console $(detect_serial_consoles); do list_console_devices $c; done)"
 	for tty in $consoles; do
 		# ignore tty devices that gives I/O error
 		if ! stty -g -F /dev/$tty >/dev/null 2>/dev/null; then
@@ -293,10 +298,10 @@ for map in "$ROOT"/etc/keymap/*; do
 done
 
 # hide kernel messages
-dmesg -n 1
-# load available drivers to get access to modloop media
+# dmesg -n 1
+# load available drivers to get access to media
 ebegin "Loading boot drivers"
-modprobe -a ahci virtio_blk virtio_net virtio_console virtio_pci nvme overlay usb_storage libata cdrom sr_mod iso9660 loop squashfs simpledrm ext4 2> /dev/null
+modprobe -a ahci virtio_blk virtio_net virtio_console virtio_pci nvme overlay usb_storage libata cdrom sr_mod iso9660 loop squashfs simpledrm ext4 tpm 2> /dev/null
 if [ -f "$ROOT"/etc/modules ] ; then
 	sed 's/\#.*//g' < /etc/modules |
 	while read module args; do
@@ -305,7 +310,7 @@ if [ -f "$ROOT"/etc/modules ] ; then
 fi
 # workaround for vmware
 if grep -q VMware /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null; then
-	modprobe -a ata_piix mptspi sr-mod
+	modprobe -a ata_piix mptspi sr-mod 2> /dev/null
 fi
 
 eend

--- a/packages/alpine/files/mkinitfs.conf
+++ b/packages/alpine/files/mkinitfs.conf
@@ -1,1 +1,1 @@
-features="ata base cdrom ext4 ext2 keymap kms mmc lvm nvme raid scsi usb network dhcp virtio zfs squashfs immucore"
+features="ata base cdrom ext4 ext2 keymap kms mmc lvm nvme raid scsi usb network dhcp virtio zfs squashfs immucore tpm"

--- a/packages/alpine/files/tpm.modules
+++ b/packages/alpine/files/tpm.modules
@@ -1,0 +1,1 @@
+kernel/drivers/char/tpm/


### PR DESCRIPTION
 - bring up to date with upstream 3.8.1 (fix for getting more console outputs)
 - add tpm modules to initramfs