### PR TITLE
Improve alpine initrd output

### DIFF
--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "alpine"
     category: "distro-kernel"
-    version: "6.1.56-4"
+    version: "6.1.56-5"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"
@@ -14,7 +14,7 @@ packages:
       package.version: "6.1.56"
   - name: "alpine-rpi"
     category: "distro-kernel"
-    version: "6.1.55-4"
+    version: "6.1.55-5"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"

--- a/packages/alpine/files/initramfs-init
+++ b/packages/alpine/files/initramfs-init
@@ -438,6 +438,9 @@ if grep -q cdroot /proc/cmdline || grep -q netboot /proc/cmdline;then
     # stop udevd, will be relaunched by openrc
     udevadm control --exit
 
+    # hide kernel messages from now on
+    dmesg -n 1
+
   	# shellcheck disable=SC2093
   	exec switch_root "$sysroot" "$INIT"
   	echo "initramfs emergency recovery shell launched"
@@ -494,7 +497,7 @@ if [ -r "$sysroot"/etc/apk/arch ]; then
 	fi
 fi
 
-
+# TODO: Use this at the start to set an aprox time for the initramfs?
 # use swclock if no RTC is found
 if rtc_exists || [ "$(uname -m)" = "s390x" ]; then
 	rc_add hwclock boot
@@ -534,7 +537,8 @@ fi
 rd_break pre-switch
 # stop udevd, will be relaunched by openrc
 udevadm control --exit
-
+# hide kernel messages from now on
+dmesg -n 1
 # switch over to new root
 echo ""
 # shellcheck disable=SC2093


### PR DESCRIPTION
Shut off dmesg to terminal just before we boot in the the rootfs to avoud polluting the running system with kernel messages