### PR TITLE
Enable network by default on alpine initramfs

### DIFF
--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "alpine"
     category: "distro-kernel"
-    version: "6.1.56-5"
+    version: "6.1.56-6"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"
@@ -14,7 +14,7 @@ packages:
       package.version: "6.1.56"
   - name: "alpine-rpi"
     category: "distro-kernel"
-    version: "6.1.55-5"
+    version: "6.1.55-6"
     description: "Provides kernel and custom initrd for alpine"
     labels:
       autobump.strategy: "custom"

--- a/packages/alpine/files/initramfs-init
+++ b/packages/alpine/files/initramfs-init
@@ -23,6 +23,18 @@ eend() {
 	fi
 }
 
+# same as eend but this wont drop us to a shell and continue booting
+eend_no_break() {
+	if [ "$1" = 0 ] || [ $# -lt 1 ] ; then
+		echo "$last_emsg: ok." > "$ROOT"/dev/kmsg
+		echo "ok."
+	else
+		shift
+		echo "$last_emsg: failed. $*" > "$ROOT"/dev/kmsg
+		echo "failed. $*"
+	fi
+}
+
 # find mount dir and mount opts for given device in an fstab
 get_fstab_mount_info() {
 	local search_dev="$1"
@@ -217,18 +229,22 @@ configure_ip() {
 
 	if [ -z "$device" ]; then
 		echo "ERROR: IP requested but no network device was found"
-		return 1
+		return 0
 	fi
 
   # automatic configuration
   if [ ! -e "$ROOT"/usr/share/udhcpc/default.script ]; then
     echo "ERROR: DHCP requested but not present in initrd"
-    return 1
+    return 0
   fi
   ebegin "Obtaining IP via DHCP ($device)"
   ifconfig "$device" 0.0.0.0
-  udhcpc -i "$device" -f -q
-  eend $?
+  # -q and -n means exit if got a lease or dont
+  # -S means log to syslog
+  # -A 10 is the timeout
+  udhcpc -i "$device" -f -q -n -S -A 10
+  eend_no_break $?
+  return 0
 }
 
 is_url() {
@@ -334,8 +350,8 @@ rd_break pre-udev
 rd_break post-udev
 
 rd_break pre-network
-# Mount network if we got rd.neednet=1 or netboot
-if grep -q "rd.neednet=1" /proc/cmdline || grep -q netboot /proc/cmdline ;then
+# Dont enable network if we got rd.neednet=0, otherwise do it by default
+if grep -vq "rd.neednet=0" /proc/cmdline;then
   configure_ip
 fi
 rd_break post-network


### PR DESCRIPTION
Can be disabled with rd.neednet=0
Make so no failure if we get no network, we tried our best Make udhcpc not block boot