### PR TITLE
Dont break inittab completely

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.3"
+    version: "1.1.4"

--- a/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
@@ -28,8 +28,8 @@ stages:
           content: |
             You are booting from livecd mode. Run 'kairos-agent install' to install the system.
           permissions: 0644
-        - path: /etc/inittab
-          content: |
-            tty1::respawn:/sbin/agetty --autologin root -i --noclear tty1
-            ttyS0::respawn:/sbin/agetty --autologin root -i --noclear ttyS0
-          permissions: 0644
+      commands:
+        - sed -i -e 's/tty1.*//g' /etc/inittab
+        - sed -i -e 's/ttyS0.*//g' /etc/inittab
+        - echo "tty1::respawn:/sbin/agetty --autologin root -i --noclear tty1" >> /etc/inittab
+        - echo "ttyS0::respawn:/sbin/agetty --autologin root -i --noclear ttyS0" >> /etc/inittab


### PR DESCRIPTION
Append to it instead of creating it from scratch as it has some defaults that are needed for the correct working of the system like openrc starting and so on