### PR TITLE
Move kernel+initrd package to provide only scripts

### DIFF
--- a/packages/alpine/build.yaml
+++ b/packages/alpine/build.yaml
@@ -1,70 +1,10 @@
-{{ if eq .Values.name "alpine-rpi" }}
-  {{ if .Values.arch }}
-  {{ if eq .Values.arch "arm64" }}
 image: alpine
-# Arm + rpi
-copy:
-  - package:
-      category: "system"
-      name: "immucore"
-      version: ">=0"
-    source: "/usr/bin/immucore"
-    destination: "/usr/bin/immucore"
-  - package:
-      category: "system"
-      name: "kairos-agent"
-      version: ">=0"
-    source: "/usr/bin/kairos-agent"
-    destination: "/usr/bin/kairos-agent"
 package_dir: "/package"
-prelude:
-  - apk update
-  # multipath-tools and cryptsetup is needed to bring modules and udev rules
-  - apk add linux-rpi4 linux-firmware-none mkinitfs dbus cloud-utils-growpart e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra sgdisk eudev eudev-hwids mdadm-udev device-mapper-udev lvm2 findmnt rsync parted cryptsetup multipath-tools openrc blkid
 steps:
-  - kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
-  - mkdir -p /package/boot
-  - mkdir -p /package/lib/modules
-  - cp /boot/vmlinuz-rpi4 /package/boot/vmlinuz
-  - cp -rfv /lib/modules/* /package/lib/modules
-  # generate initramfs
-  - cp files/immucore.files /etc/mkinitfs/features.d/immucore.files
-  - cp files/tpm.modules /etc/mkinitfs/features.d/tpm.modules
-  - kernel=$(ls /lib/modules | head -n1) && mkinitfs -o /package/boot/initrd -i files/initramfs-init -c files/mkinitfs.conf $kernel
-    {{end}}
-  {{end}}
-  {{else}}
-image: alpine
-# x86 + arm + no rpi path
-copy:
-  - package:
-      category: "system"
-      name: "immucore"
-      version: ">=0"
-    source: "/usr/bin/immucore"
-    destination: "/usr/bin/immucore"
-  - package:
-      category: "system"
-      name: "kairos-agent"
-      version: ">=0"
-    source: "/usr/bin/kairos-agent"
-    destination: "/usr/bin/kairos-agent"
-package_dir: "/package"
-prelude:
-  - apk update
-  # multipath-tools and cryptsetup is needed to bring modules and udev rules
-  - apk add linux-lts linux-firmware-none mkinitfs dbus cloud-utils-growpart e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra sgdisk eudev eudev-hwids mdadm-udev device-mapper-udev lvm2 findmnt rsync parted cryptsetup multipath-tools openrc blkid
-steps:
-  - kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
-  - mkdir -p /package/boot
-  - mkdir -p /package/lib/modules
-  # TODO: Add firmware files
-  - cp /boot/vmlinuz-lts /package/boot/vmlinuz
-  - cp -rfv /lib/modules/* /package/lib/modules
-  # generate initramfs
-  - cp files/immucore.files /etc/mkinitfs/features.d/immucore.files
-  - cp files/tpm.modules /etc/mkinitfs/features.d/tpm.modules
-  - kernel=$(ls /lib/modules | head -n1) && mkinitfs -o /package/boot/initrd -i files/initramfs-init -c files/mkinitfs.conf $kernel
-{{end}}
-
-
+  - mkdir -p /packages/etc/mkinitfs/features.d
+  - mkdir -p /packages/etc/mkinitfs/
+  - mkdir -p /packages/usr/share/mkinitfs/
+  - cp files/immucore.files /packages/etc/mkinitfs/features.d/immucore.files
+  - cp files/tpm.modules /packages/etc/mkinitfs/features.d/tpm.modules
+  - cp files/mkinitfs.conf /packages/etc/mkinitfs/mkinitfs.conf
+  - cp files/initramfs-init /packages/usr/share/mkinitfs/initramfs-init

--- a/packages/alpine/build.yaml
+++ b/packages/alpine/build.yaml
@@ -1,10 +1,10 @@
 image: alpine
 package_dir: "/package"
 steps:
-  - mkdir -p /packages/etc/mkinitfs/features.d
-  - mkdir -p /packages/etc/mkinitfs/
-  - mkdir -p /packages/usr/share/mkinitfs/
-  - cp files/immucore.files /packages/etc/mkinitfs/features.d/immucore.files
-  - cp files/tpm.modules /packages/etc/mkinitfs/features.d/tpm.modules
-  - cp files/mkinitfs.conf /packages/etc/mkinitfs/mkinitfs.conf
-  - cp files/initramfs-init /packages/usr/share/mkinitfs/initramfs-init
+  - mkdir -p /package/etc/mkinitfs/features.d
+  - mkdir -p /package/etc/mkinitfs/
+  - mkdir -p /package/usr/share/mkinitfs/
+  - cp files/immucore.files /package/etc/mkinitfs/features.d/immucore.files
+  - cp files/tpm.modules /package/etc/mkinitfs/features.d/tpm.modules
+  - cp files/mkinitfs.conf /package/etc/mkinitfs/mkinitfs.conf
+  - cp files/initramfs-init /package/usr/share/mkinitfs/initramfs-init

--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,27 +1,7 @@
 packages:
   - name: "alpine"
-    category: "distro-kernel"
-    version: "6.1.56-6"
-    description: "Provides kernel and custom initrd for alpine"
-    labels:
-      autobump.strategy: "custom"
-      autobump.string_replace: '{ "prefix": "" }'
-      autobump.prefix: "prefix"
-      autobump.hook: |
-        curl -s https://raw.githubusercontent.com/alpinelinux/aports/3.18-stable/main/linux-lts/APKBUILD | grep "pkgver=" | awk -F"=" '{print $2}'
-      autobump.version_hook: |
-        curl -s https://raw.githubusercontent.com/alpinelinux/aports/3.18-stable/main/linux-lts/APKBUILD | grep "pkgver=" | awk -F"=" '{print $2}'
-      package.version: "6.1.56"
-  - name: "alpine-rpi"
-    category: "distro-kernel"
-    version: "6.1.55-6"
-    description: "Provides kernel and custom initrd for alpine"
-    labels:
-      autobump.strategy: "custom"
-      autobump.string_replace: '{ "prefix": "" }'
-      autobump.prefix: "prefix"
-      autobump.hook: |
-        curl -s https://raw.githubusercontent.com/alpinelinux/aports/3.18-stable/main/linux-rpi/APKBUILD | grep "pkgver=" | awk -F"=" '{print $2}'
-      autobump.version_hook: |
-        curl -s https://raw.githubusercontent.com/alpinelinux/aports/3.18-stable/main/linux-rpi/APKBUILD | grep "pkgver=" | awk -F"=" '{print $2}'
-      package.version: "6.1.55"
+    category: "initrd"
+    version: "3.8.1"
+    description: "Provides custom initrd scripts for alpine"
+# This syncs with the alpine version at https://gitlab.alpinelinux.org/alpine/mkinitfs/-/blob/master/initramfs-init.in?ref_type=heads
+# any changes to the initramfs-init.in file should be looked at and backported if necessary

--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "alpine"
     category: "initrd"
-    version: "3.8.1"
+    version: "3.8.1+1"
     description: "Provides custom initrd scripts for alpine"
 # This syncs with the alpine version at https://gitlab.alpinelinux.org/alpine/mkinitfs/-/blob/master/initramfs-init.in?ref_type=heads
 # any changes to the initramfs-init.in file should be looked at and backported if necessary


### PR DESCRIPTION
So we can build it as part of the build process

Signed-off-by: Itxaka <itxaka@kairos.io>