### PR TITLE
insmod regexp in grub otherwise our bootargs.cfg logic won't work

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.8"
+version: "0.9"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -57,6 +57,7 @@ insmod all_video
 insmod loopback
 insmod squash4
 insmod serial
+insmod regexp
 loadfont unicode
 
 menuentry "${display_name}" --id cos {


### PR DESCRIPTION
This should allow us to release v2.4.2 on kairos