### PR TITLE
Make tty1 the default console and let kairos service logs there

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.12"
+    version: "1.1.13"

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -51,7 +51,7 @@ function setKernelCmd {
     setExtraConsole
     setExtraArgs
     # finally set the full cmdline
-    set kernelcmd="$baseCmd $baseRootCmd $baseSelinuxCmd $baseExtraConsole $baseExtraArgs"
+    set kernelcmd="$baseExtraConsole $baseCmd $baseRootCmd $baseSelinuxCmd $baseExtraArgs"
 }
 
 

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=tty
+StandardOutput=journal+console
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=tty
+StandardOutput=journal+console
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=2500000"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=tty
+StandardOutput=journal+console
 LimitNOFILE=49152
 TTYPath=/dev/tty1
 RemainAfterExit=yes

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=tty
+StandardOutput=journal+console
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1


### PR DESCRIPTION
The order in the cmdline matters and it seems that the last one defined is the "default" console. Setting StandardOutput to journal+console makes `journalctl -u kairos` print the installer logs (maintaining the existing behaviour of printing them in tty1)

This should allow us to refactor the test here: https://github.com/kairos-io/kairos-agent/pull/174#issuecomment-1819318236

because then we will have access to the installer logs using `journalctl` 