### PR TITLE
Fix services tty output

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.13"
+    version: "1.1.14"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -3,7 +3,7 @@ Description=kairos interactive-installer
 After=sysinit.target
 [Service]
 Type=oneshot
-# imput/output to tty as its interactive
+# input/output to tty as its interactive
 # otherwise it will be silent and with no input
 StandardInput=tty
 StandardOutput=tty

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -3,12 +3,15 @@ Description=kairos interactive-installer
 After=sysinit.target
 [Service]
 Type=oneshot
+# imput/output to tty as its interactive
+# otherwise it will be silent and with no input
 StandardInput=tty
-StandardOutput=journal+console
+StandardOutput=tty
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1
 RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent interactive-install --shell
+TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=journal+console
+StandardOutput=tty
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=2500000"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
@@ -4,10 +4,11 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=journal+console
+StandardOutput=tty
 LimitNOFILE=49152
 TTYPath=/dev/tty1
 RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent reset --unattended --reboot
+TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
@@ -4,7 +4,7 @@ After=sysinit.target
 [Service]
 Type=oneshot
 StandardInput=tty
-StandardOutput=journal+console
+StandardOutput=tty
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1


### PR DESCRIPTION
 - interactive installer: output was not connected to tty so it was impossible to answer any questions
 - reset: was not getting the output and taking over the tty so it got overwritten by other output. It could be stopped in the middle
 - installer: same as above but it could lead to stopping the install in the middle of it
 - recovery: same as above, QR code didnt even display