### PR TITLE
Fix services output

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.14"
+    version: "1.1.15"

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -41,7 +41,7 @@ function setKernelCmd {
     # baseSelinuxCmd -> selinux enabled/disabled
     # baseExtraConsole -> extra console to set
     # baseExtraArgs -> extra needed args
-    set baseCmd="console=tty1 net.ifnames=1 rd.cos.oemlabel=COS_OEM rd.cos.oemtimeout=10 panic=5 rd.emergency=reboot rd.shell=0 systemd.crash_reboot=yes systemd.show_status=no"
+    set baseCmd="console=tty1 net.ifnames=1 rd.cos.oemlabel=COS_OEM rd.cos.oemtimeout=10 panic=5 rd.emergency=reboot rd.shell=0 systemd.crash_reboot=yes"
     if [ -n "$recoverylabel" ]; then
         set baseRootCmd="root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img"
     else

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -41,7 +41,7 @@ function setKernelCmd {
     # baseSelinuxCmd -> selinux enabled/disabled
     # baseExtraConsole -> extra console to set
     # baseExtraArgs -> extra needed args
-    set baseCmd="console=tty1 net.ifnames=1 rd.cos.oemlabel=COS_OEM rd.cos.oemtimeout=10 panic=5 rd.emergency=reboot rd.shell=0 systemd.crash_reboot=yes"
+    set baseCmd="console=tty1 net.ifnames=1 rd.cos.oemlabel=COS_OEM rd.cos.oemtimeout=10 panic=5 rd.emergency=reboot rd.shell=0 systemd.crash_reboot=yes systemd.show_status=no"
     if [ -n "$recoverylabel" ]; then
         set baseRootCmd="root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img"
     else

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -11,7 +11,11 @@ LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1
 RemainAfterExit=yes
+# Stop systemd messages on tty
+ExecStartPre=-/usr/bin/kill -SIGRTMIN+21 1
 ExecStart=/usr/bin/kairos-agent interactive-install --shell
+# Start systemd messages on tty
+ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -8,8 +8,12 @@ StandardOutput=tty
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=2500000"
+# Stop systemd messages on tty
+ExecStartPre=-/usr/bin/kill -SIGRTMIN+21 1
 TTYPath=/dev/tty1
 RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent recovery
+# Start systemd messages on tty
+ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
@@ -8,7 +8,11 @@ StandardOutput=tty
 LimitNOFILE=49152
 TTYPath=/dev/tty1
 RemainAfterExit=yes
+# Stop systemd messages on tty
+ExecStartPre=-/usr/bin/kill -SIGRTMIN+21 1
 ExecStart=/usr/bin/kairos-agent reset --unattended --reboot
+# Start systemd messages on tty
+ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
@@ -9,7 +9,11 @@ LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1
 RemainAfterExit=yes
+# Stop systemd messages on tty
+ExecStartPre=-/usr/bin/kill -SIGRTMIN+21 1
 ExecStart=/usr/bin/kairos-agent install
+# Start systemd messages on tty
+ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
@@ -7,6 +7,8 @@ stages:
         ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
+        - systemctl stop getty@tty1
+        - systemctl mask getty@tty1
         - systemctl enable kairos-recovery
     - name: "Starts kairos-recovery for openRC based systems"
       if: grep -q "kairos.remote_recovery_mode" /proc/cmdline &&  [ -f "/sbin/openrc" ]

--- a/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
@@ -5,6 +5,8 @@ stages:
       if: grep -q "kairos.reset" /proc/cmdline && [ ! -f "/sbin/openrc" ]
       commands:
         - systemctl disable getty@tty1
+        - systemctl stop getty@tty1
+        - systemctl mask getty@tty1
         - systemctl enable kairos-reset
     - name: "Starts kairos-reset for openRC-based systems"
       if: grep -q "kairos.reset" /proc/cmdline && [ -f "/sbin/openrc" ]

--- a/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
@@ -6,6 +6,8 @@ stages:
           ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
+        - systemctl stop getty@tty1
+        - systemctl mask getty@tty1
         - systemctl enable kairos
         - systemctl enable kairos-webui
     # Starts installer on boot for openRC based systems
@@ -19,6 +21,8 @@ stages:
         ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
+        - systemctl stop getty@tty1
+        - systemctl mask getty@tty1
         - systemctl enable kairos-interactive
     # Starts installer on boot for openRC based systems
     - if: grep -q "interactive-install" /proc/cmdline && [ -f "/sbin/openrc" ]


### PR DESCRIPTION
 - make sure getty is stopped and masked in case other service tries to bring it up when we are running reset,recovery or installers
 - make systemd nto show the output in the main tty by default so it doesnt pollute the tty with messages afterwards