### PR TITLE
Enable MAC as DHCP client identifier

### DIFF
--- a/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
@@ -18,6 +18,8 @@ stages:
             Name=en*
             [Network]
             DHCP=yes
+            [DHCP]
+            ClientIdentifier=mac
         - path: /etc/systemd/network/20-dhcp-legacy.network
           permissions: 0644
           owner: 0
@@ -27,6 +29,8 @@ stages:
             Name=eth*
             [Network]
             DHCP=yes
+            [DHCP]
+            ClientIdentifier=mac
       commands:
         - networkctl reload # make sure it reloads our config files
   initramfs:
@@ -42,6 +46,8 @@ stages:
             Name=en*
             [Network]
             DHCP=yes
+            [DHCP]
+            ClientIdentifier=mac
         - path: /etc/systemd/network/20-dhcp-legacy.network
           permissions: 0644
           owner: 0
@@ -51,6 +57,8 @@ stages:
             Name=eth*
             [Network]
             DHCP=yes
+            [DHCP]
+            ClientIdentifier=mac
       commands:
         - networkctl reload # make sure it reloads our config files
     - name: "Disable NetworkManager and wicked"


### PR DESCRIPTION
This PR adjusts the default DHCP configuration to use the Client Identifier for DHCP from a random GUID to the NIC's MAC address. This brings it in line with every other OS and customer expectations. It ensures that the Edge device receives the same DHCP lease from the DHCP server as long as the lease is still valid.