### PR TITLE
Move grub provider to tumbleweed

### DIFF
--- a/packages/livecd/grub2/build.yaml
+++ b/packages/livecd/grub2/build.yaml
@@ -1,4 +1,4 @@
-image: "opensuse/leap:15.5"
+image: {{.Values.image}}
 
 prelude:
 {{if .Values.arch }}

--- a/packages/livecd/grub2/collection.yaml
+++ b/packages/livecd/grub2/collection.yaml
@@ -3,7 +3,28 @@ packages:
     category: "livecd"
     version: "0.0.12"
     description: "Grub2 bootloader for live systems"
+    image: "registry.opensuse.org/opensuse/tumbleweed"
+    labels:
+      autobump.strategy: "custom"
+      autobump.string_replace: '{ "prefix": "" }'
+      autobump.prefix: "prefix"
+      autobump.hook: |
+        curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+      autobump.version_hook: |
+        curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+      package.version: "2.06-150500.27.4"
   - name: "grub2-efi-image"
     category: "livecd"
     version: "0.0.12"
     description: "Grub2 bootloader EFI image for live systems"
+    image: "registry.opensuse.org/opensuse/tumbleweed"
+    labels:
+      autobump.strategy: "custom"
+      autobump.string_replace: '{ "prefix": "" }'
+      autobump.prefix: "prefix"
+      autobump.hook: |
+        curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+      autobump.version_hook: |
+        curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+      package.version: "2.06-150500.27.4"
+

--- a/packages/livecd/grub2/collection.yaml
+++ b/packages/livecd/grub2/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "grub2"
     category: "livecd"
-    version: "0.0.12"
+    version: "0.0.12-1"
     description: "Grub2 bootloader for live systems"
     image: "registry.opensuse.org/opensuse/tumbleweed"
     labels:
@@ -15,7 +15,7 @@ packages:
       package.version: "2.06-150500.27.4"
   - name: "grub2-efi-image"
     category: "livecd"
-    version: "0.0.12"
+    version: "0.0.12-1"
     description: "Grub2 bootloader EFI image for live systems"
     image: "registry.opensuse.org/opensuse/tumbleweed"
     labels:

--- a/packages/system/grub2-efi/build.yaml
+++ b/packages/system/grub2-efi/build.yaml
@@ -1,4 +1,4 @@
-image: registry.opensuse.org/opensuse/leap:15.5
+image: {{.Values.image}}
 
 prelude:
 - zypper ref

--- a/packages/system/grub2-efi/definition.yaml
+++ b/packages/system/grub2-efi/definition.yaml
@@ -1,6 +1,6 @@
 name: "grub2-efi"
 category: "system"
-version: "2.06-150500.27.4"
+version: "2.06-150500.27.4-1"
 license: "GPL-3.0-or-later"
 image: "registry.opensuse.org/opensuse/tumbleweed"
 labels:

--- a/packages/system/grub2-efi/definition.yaml
+++ b/packages/system/grub2-efi/definition.yaml
@@ -2,12 +2,13 @@ name: "grub2-efi"
 category: "system"
 version: "2.06-150500.27.4"
 license: "GPL-3.0-or-later"
+image: "registry.opensuse.org/opensuse/tumbleweed"
 labels:
   autobump.strategy: "custom"
   autobump.string_replace: '{ "prefix": "" }'
   autobump.prefix: "prefix"
   autobump.hook: |
-    curl -s -L https://download.opensuse.org/distribution/leap/15.5/repo/oss/$(curl -s -L https://download.opensuse.org/distribution/leap/15.5/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | gunzip | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+    curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
   autobump.version_hook: |
-    curl -s -L https://download.opensuse.org/distribution/leap/15.5/repo/oss/$(curl -s -L https://download.opensuse.org/distribution/leap/15.5/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | gunzip | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
+    curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/$(curl -s -L https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml | dasel -r xml 'repomd.data.[0].location.-href') | zstd -d - | dasel -r xml -w json | jq '.metadata.package[] | select(.name|match("grub2-x86_64-efi$")) | select(.arch!="src").version | map(.)[2] + "-" +  map(.)[1]' -r | tail -n1
   package.version: "2.06-150500.27.4"


### PR DESCRIPTION
This bumps grub to 2.12 which should bring fixes

Potentially this can bring the tpm out of memory issue back, but I would like to retest it as it brings a lot of fixex and improvements to grub, potentially including secureboot fixes