### PR TITLE
Disable tpm module on efi for grub

### DIFF
--- a/packages/static/grub-config/definition.yaml
+++ b/packages/static/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "static"
-version: "0.9"
+version: "0.10"

--- a/packages/static/grub-config/files/grub.cfg
+++ b/packages/static/grub-config/files/grub.cfg
@@ -59,6 +59,10 @@ insmod squash4
 insmod serial
 insmod regexp
 loadfont unicode
+if [ "${grub_platform}" = "efi" ]; then
+    ## workaround for grub2-efi bug: https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1851311
+    rmmod tpm
+fi
 
 menuentry "${display_name}" --id cos {
   search --no-floppy --label --set=root COS_STATE


### PR DESCRIPTION
It runs out of memory when loading the loop device as it tries to measure the full file by loading it into memory

Part of supposrting secureboot in all flavors