### PR TITLE
Fix agent state get init

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.24"
+    version: "1.1.25"

--- a/packages/static/kairos-overlay-files/files/system/oem/02_agent.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/02_agent.yaml
@@ -1,11 +1,11 @@
 name: "Start agent"
 stages:
   boot:
-    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -d "/usr/share/systemd" ]'
       commands:
         - systemctl start kairos-agent
         - systemctl enable kairos-agent
   initramfs:
-    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -d "/usr/share/systemd" ]'
       commands:
         - systemctl enable kairos-agent

--- a/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
@@ -2,7 +2,7 @@ name: "Default network configuration"
 stages:
   rootfs.before:
     - name: "Enable systemd-network config files for DHCP" # Needed if systemd-networkd runs in the initramfs!
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       directories:
         - path: "/etc/systemd/network/" # doesnt exist on initramfs
           permissions: 0775
@@ -35,7 +35,7 @@ stages:
         - networkctl reload # make sure it reloads our config files
   initramfs:
     - name: "Enable systemd-network config files for DHCP"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       files:
         - path: /etc/systemd/network/20-dhcp.network
           permissions: 0644
@@ -62,30 +62,30 @@ stages:
       commands:
         - networkctl reload # make sure it reloads our config files
     - name: "Disable NetworkManager and wicked"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       systemctl:
         disable:
           - NetworkManager
           - wicked
     - name: "Enable systemd-network and systemd-resolved"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       systemctl:
         enable:
           - systemd-networkd
           - systemd-resolved
     - name: "Link /etc/resolv.conf to systemd resolv.conf"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ] && [ -f /etc/hosts ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] && [ -f /etc/hosts ]'
       commands:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
   boot:
     - name: "Reload systemd-networkd config"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       commands:
         - networkctl reload # make sure it reloads our config files
   fs:
     - name: "Reload systemd-networkd config"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       commands:
         - networkctl reload # make sure it reloads our config files
 #     dns:

--- a/packages/static/kairos-overlay-files/files/system/oem/09_openrc_services.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/09_openrc_services.yaml
@@ -3,7 +3,7 @@ stages:
   initramfs:
     - name: "Create OpenRC services"
       if: |
-        [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+        [ -f "/sbin/openrc" ]
       files:
       - path: /etc/init.d/cos-setup-boot
         permissions: 0755
@@ -118,7 +118,7 @@ stages:
         group: 0
     - name: "Enable OpenRC services"
       if: |
-        [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+        [ -f "/sbin/openrc" ]
       commands:
         - mkdir -p /etc/runlevels/default
         - ln -sf ../../init.d/cos-setup-boot /etc/runlevels/default/cos-setup-boot

--- a/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
@@ -13,7 +13,7 @@ stages:
         fs.inotify.max_user_watches: 524288
   initramfs:
     - name: "Default systemd config"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       systemctl:
         enable:
           - multi-user.target
@@ -34,7 +34,7 @@ stages:
       commands:
       - ssh-keygen -A
     - name: "Create systemd services"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       files:
         - path: /etc/systemd/system/cos-setup-boot.service
           permissions: 0644
@@ -123,7 +123,7 @@ stages:
             [Install]
             WantedBy=multi-user.target
     - name: "Enable systemd services"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       commands:
         - ln -sf /etc/systemd/system/cos-setup-reconcile.timer /etc/systemd/system/multi-user.target.wants/cos-setup-reconcile.timer
         - ln -sf /etc/systemd/system/cos-setup-fs.service /etc/systemd/system/sysinit.target.wants/cos-setup-fs.service

--- a/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
@@ -52,7 +52,7 @@ stages:
     # Run this in the after stage so it doesnt collide with other initramfs changes to the /etc/inittab
     # Otherwise this can lead to 2 steps modifying the inittab at the same time and overriding or not cleaning it properly
     - name: "Enable serial login for alpine" # https://wiki.alpinelinux.org/wiki/Enable_Serial_Console_on_Boot
-      if: '[ "$(kairos-agent state get kairos.init)" == "openrc" ]'
+      if: '[ -e /sbin/openrc ]'
       commands:
         - sed -i -e 's/ttyS0.*//g' /etc/inittab
         - echo "ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100" >> /etc/inittab

--- a/packages/static/kairos-overlay-files/files/system/oem/24_sysext.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/24_sysext.yaml
@@ -2,7 +2,7 @@ name: "sysext"
 stages:
   fs.after:
     - name: "Default sysext extensions dirs"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       directories:
         - path: /etc/extensions
         - path: /run/extensions
@@ -11,7 +11,7 @@ stages:
         - path: /usr/local/lib/extensions
   initramfs:
     - name: "systemd-sysext initramfs settings"
-      if: '[ "$(kairos-agent state get kairos.init)" == "systemd" ]'
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       systemctl:
         enable:
           - systemd-sysext

--- a/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
@@ -4,7 +4,8 @@ stages:
     # TODO: Drop interactive-install keyword in Kairos 4.0.0
     - if: |
         (grep -qv "interactive-install" /proc/cmdline || grep -qv "install-mode-interactive" /proc/cmdline ) && \
-        [ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ] && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+        [ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ] && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       files:
         - path: /etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
           content: |
@@ -23,7 +24,7 @@ stages:
       if: |
         (grep -qv "interactive-install" /proc/cmdline || grep -qv "install-mode-interactive" /proc/cmdline) && \
         [ -f /run/cos/live_mode ] && \
-        [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+        [ -f "/sbin/openrc" ]
       files:
         - path: /etc/motd
           content: |

--- a/packages/static/kairos-overlay-files/files/system/oem/29_blacklist.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/29_blacklist.yaml
@@ -1,6 +1,6 @@
 stages:
   initramfs.before:
     - name: "Blacklist bpfilter on Alpine ( bug: https://github.com/kairos-io/kairos/issues/277 )"
-      if: '[ "$(kairos-agent state get kairos.init)" == "openrc" ]'
+      if: '[ -e /sbin/openrc ]'
       commands:
         - echo "install bpfilter /bin/false" > /etc/modprobe.d/blacklist_bpfilter.conf

--- a/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
@@ -3,14 +3,15 @@ stages:
   initramfs:
     - name: "Starts kairos-recovery and generate a temporary pass"
       if: |
-        grep -q "kairos.remote_recovery_mode" /proc/cmdline && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+        grep -q "kairos.remote_recovery_mode" /proc/cmdline && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
         - systemctl stop getty@tty1
         - systemctl mask getty@tty1
         - systemctl enable kairos-recovery
     - name: "Starts kairos-recovery for openRC based systems"
-      if: grep -q "kairos.remote_recovery_mode" /proc/cmdline && [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+      if: grep -q "kairos.remote_recovery_mode" /proc/cmdline && [ -f "/sbin/openrc" ]
       commands:
         - sed -i -e 's/tty1.*//g' /etc/inittab
         - echo "tty1::respawn:/usr/bin/kairos-agent recovery tty1" >> /etc/inittab

--- a/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
@@ -3,14 +3,15 @@ stages:
   initramfs:
     - name: "Starts kairos-reset for systemd based systems"
       if: |
-        grep -q "kairos.reset" /proc/cmdline && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+        grep -q "kairos.reset" /proc/cmdline && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
         - systemctl stop getty@tty1
         - systemctl mask getty@tty1
         - systemctl enable kairos-reset
     - name: "Starts kairos-reset for openRC-based systems"
-      if: grep -q "kairos.reset" /proc/cmdline && [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+      if: grep -q "kairos.reset" /proc/cmdline && [ -f "/sbin/openrc" ]
       commands:
         - sed -i -e 's/tty1.*//g' /etc/inittab
         - echo "tty1::respawn:/usr/bin/kairos-agent reset tty1" >> /etc/inittab

--- a/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
@@ -5,7 +5,10 @@ stages:
     # and we dont want to trigger both
     # Works in livecd or uki install mode
     # TODO: Drop nodepair.enable keyword in Kairos 4.0.0
-    - if: (grep -q "install-mode" /proc/cmdline || grep -q "nodepair.enable" /proc/cmdline ) && grep -vq "install-mode-interactive" && ([ "$(kairos-agent state get boot)" == "livecd_boot" ] || [ -f /run/cos/uki_install_mode ]) && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+    - if: |
+        (grep -q "install-mode" /proc/cmdline || grep -q "nodepair.enable" /proc/cmdline ) && \
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl disable getty@tty1
         - systemctl stop getty@tty1
@@ -14,14 +17,19 @@ stages:
         - systemctl enable kairos-webui
     # Starts installer on boot for openRC based systems
     # TODO: Drop nodepair.enable keyword in Kairos 4.0.0
-    - if: (grep -q "install-mode" /proc/cmdline || grep -q "nodepair.enable" /proc/cmdline ) && grep -vq "install-mode-interactive" && [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+    - if: |
+        (grep -q "install-mode" /proc/cmdline || grep -q "nodepair.enable" /proc/cmdline ) && \
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        [ -f "/sbin/openrc" ]
       commands:
         - sed -i -e 's/tty1.*//g' /etc/inittab
         - echo "tty1::respawn:/usr/bin/kairos-agent install tty1" >> /etc/inittab
     # Starts interactive installer on boot for systemd based systems in livecd or uki install mode
     # TODO: Drop interactive-install keyword in Kairos 4.0.0
     - if: |
-        (grep -q "interactive-install" /proc/cmdline || grep -q "install-mode-interactive" /proc/cmdline) && ([ "$(kairos-agent state get boot)" == "livecd_boot" ] || [ -f /run/cos/uki_install_mode ]) && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+        (grep -q "interactive-install" /proc/cmdline || grep -q "install-mode-interactive" /proc/cmdline) && \
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl stop kairos
         - systemctl disable kairos
@@ -31,16 +39,21 @@ stages:
         - systemctl enable kairos-interactive
     # Starts installer on boot for openRC based systems
     # TODO: Drop interactive-install keyword in Kairos 4.0.0
-    - if: (grep -q "interactive-install" /proc/cmdline || grep -q "install-mode-interactive" /proc/cmdline) && [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+    - if: |
+        (grep -q "interactive-install" /proc/cmdline || grep -q "install-mode-interactive" /proc/cmdline) && \
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        [ -f "/sbin/openrc" ]
       commands:
         - sed -i -e 's/tty1.*//g' /etc/inittab
         - echo "tty1::respawn:/usr/bin/kairos-agent interactive-install --shell tty1" >> /etc/inittab
   boot:
     - if: |
-        [ "$(kairos-agent state get boot)" == "livecd_boot" ] && [ "$(kairos-agent state get kairos.init)" == "openrc" ]
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        [ -f "/sbin/openrc" ]
       commands:
         - rc-service kairos-webui start
     - if: | 
-        ([ "$(kairos-agent state get boot)" == "livecd_boot" ] || [ -f /run/cos/uki_install_mode ]) && [ "$(kairos-agent state get kairos.init)" == "systemd" ]
+        ([ -f /run/cos/live_mode ] || [ -f /run/cos/uki_install_mode ]) && \
+        ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
       commands:
         - systemctl start kairos-webui


### PR DESCRIPTION
getting vars from the agent state does seem to work, making everything fail to check the init system