### PR TITLE
Fix auto reset on alpine

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.30"
+    version: "1.1.31"

--- a/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
@@ -14,4 +14,4 @@ stages:
       if: grep -q "kairos.reset" /proc/cmdline && [ -f "/sbin/openrc" ]
       commands:
         - sed -i -e 's/tty1.*//g' /etc/inittab
-        - echo "tty1::respawn:/usr/bin/kairos-agent reset tty1" >> /etc/inittab
+        - echo "tty1::respawn:/usr/bin/kairos-agent reset --unattended --reboot tty1" >> /etc/inittab


### PR DESCRIPTION
Agent needs to know that we are running unnatended AND we want to reboot when its done for the auto reset to behave as expected

Fixes: https://github.com/kairos-io/kairos/issues/2136