### PR TITLE
Bump kairos-agent to v2.8.7

### DIFF
--- a/packages/system/kairos-agent/collection.yaml
+++ b/packages/system/kairos-agent/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "kairos-agent"
     category: "system"
-    version: "2.8.6"
+    version: "2.8.7"
     labels:
       github.repo: "kairos-agent"
       autobump.revdeps: "true"
@@ -12,7 +12,7 @@ packages:
     description: "Lifecycle agent for kairos"
   - name: "kairos-agent"
     category: "fips"
-    version: "2.8.6"
+    version: "2.8.7"
     labels:
       github.repo: "kairos-agent"
       autobump.revdeps: "true"


### PR DESCRIPTION
Fixes issue with bootentry command on UKI