### PR TITLE
Improve alpine initrd boot media

### DIFF
--- a/packages/alpine/collection.yaml
+++ b/packages/alpine/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "alpine"
     category: "initrd"
-    version: "3.8.1+2"
+    version: "3.8.1+3"
     description: "Provides custom initrd scripts for alpine"
 # This syncs with the alpine version at https://gitlab.alpinelinux.org/alpine/mkinitfs/-/blob/master/initramfs-init.in?ref_type=heads
 # any changes to the initramfs-init.in file should be looked at and backported if necessary

--- a/packages/alpine/files/initramfs-init
+++ b/packages/alpine/files/initramfs-init
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=3.8.1-kairos1
+VERSION=3.8.1-kairos2
 INIT=/sbin/init
 sysroot="$ROOT"/sysroot
 
@@ -393,19 +393,19 @@ fi
 # Path for booting from livecd
 if grep -q cdroot /proc/cmdline ;then
   rd_break pre-livecd
-  echo "Mounting LiveCD"
+  echo "Mounting Live Media"
   sync
   # Create mountpoints
   ebegin "Create mountpoints"
   mkdir -p /media/root-ro /media/root-rw /run/rootfsbase $sysroot/media/root-ro $sysroot/media/root-rw $sysroot/run/rootfsbase
   eend $?
   # Between udev starting, we loading the modules and the cdrom appearing sometimes there is a delay, so lets wait a bit here
-  ebegin "Waiting for cdrom to be available"
-  retry 10 test -e /dev/sr0
+  ebegin "Waiting for Live Media to be available"
+  retry 10 test -e /dev/disk/by-label/COS_LIVE
   eend
   # Mount read-only livecd
-  ebegin "Mount LiveCD RO"
-  retry 10 mount /dev/sr0 /media/root-ro
+  ebegin "Mount Live Media RO"
+  retry 10 mount /dev/disk/by-label/COS_LIVE /media/root-ro
   eend $?
   sync
   # Mount squashfs into loop device


### PR DESCRIPTION
Use the LiveCD label to search for the install media, not the hardcoded cdrom

Probably fixes: https://github.com/kairos-io/kairos/issues/2464