### PR TITLE
Re-introduce webui dependencies for kairos-agent

### DIFF
--- a/packages/system/kairos-agent/build.yaml
+++ b/packages/system/kairos-agent/build.yaml
@@ -23,6 +23,8 @@ env:
 {{else}}
   - CGO_ENABLED=0
 {{end}}
+# Deps for webui
+  - cd /go/src/github.com/${GITHUB_ORG}/{{ .Values.name }}/internal/webui/public && npm install
 steps:
   - |
     PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \

--- a/packages/system/kairos-agent/collection.yaml
+++ b/packages/system/kairos-agent/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "kairos-agent"
     category: "system"
-    version: "2.9.0"
+    version: "2.9.0+1"
     labels:
       github.repo: "kairos-agent"
       autobump.revdeps: "true"
@@ -12,7 +12,7 @@ packages:
     description: "Lifecycle agent for kairos"
   - name: "kairos-agent"
     category: "fips"
-    version: "2.9.0"
+    version: "2.9.0+1"
     labels:
       github.repo: "kairos-agent"
       autobump.revdeps: "true"


### PR DESCRIPTION
These were removed by mistake when making the binaries smaller for UKI

relates to kairos-io/kairos#2473