### PR TITLE
bump k3s packages

### DIFF
--- a/packages/k8s/k3s/collection.yaml
+++ b/packages/k8s/k3s/collection.yaml
@@ -14,7 +14,7 @@ packages:
     description: " Lightweight Kubernetes "
   - name: k3s-openrc
     category: k8s
-    version: "1.28.5+4"
+    version: "1.28.9"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -27,7 +27,7 @@ packages:
     description: " Lightweight Kubernetes "
   - name: k3s-openrc
     category: k8s
-    version: "1.27.9+4"
+    version: "1.29.4"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -53,7 +53,7 @@ packages:
     description: " Lightweight Kubernetes "
   - name: k3s-systemd
     category: k8s
-    version: "1.28.5+4"
+    version: "1.28.9"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"
@@ -66,7 +66,7 @@ packages:
     description: " Lightweight Kubernetes "
   - name: k3s-systemd
     category: k8s
-    version: "1.27.9+4"
+    version: "1.29.4"
     k3s_version: "2"
     labels:
       github.owner: "k3s-io"


### PR DESCRIPTION
K3s was bumped to the latest version 1.30.0 but the two following versions have not been updated for a while