### PR TITLE
Fix golang not updating properly

### DIFF
--- a/packages/toolchain-go/build.yaml
+++ b/packages/toolchain-go/build.yaml
@@ -1,7 +1,8 @@
+{{ $version := semver .Values.version  }}
 {{ if .Values.variant }}
-image: "golang:{{.Values.tag}}-{{.Values.variant}}"
+image: "golang:{{ $version.Major }}.{{$version.Minor}}.{{$version.Patch }}-{{.Values.variant}}"
 {{ else }}
-image: "golang:{{.Values.tag}}"
+image: "golang:{{ $version.Major }}.{{$version.Minor}}.{{$version.Patch }}"
 {{ end }}
 
 prelude:

--- a/packages/toolchain-go/collection.yaml
+++ b/packages/toolchain-go/collection.yaml
@@ -2,8 +2,7 @@ packages:
   - name: toolchain-go
     category: development
     variant: "alpine"
-    version: "1.22.4"
-    tag: "1.21.6"
+    version: "1.22.4+1"
     hidden: true
     labels:
       autobump.revdeps: "false"
@@ -18,8 +17,7 @@ packages:
   - name: toolchain-go-ubuntu
     variant: "bookworm"
     category: development
-    version: "1.22.4"
-    tag: "1.21.7"
+    version: "1.22.4+1"
     hidden: true
     labels:
       autobump.revdeps: "false"


### PR DESCRIPTION
Tag was not updated, so version bumped but didnt really bump the golang version.

also fixes any revision that we add