### PR TITLE
disable selinux on opensuse-leap

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.38"
+    version: "1.1.39"

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -1,7 +1,7 @@
 function setSelinux {
     source (loop0)/etc/os-release
     set baseSelinuxCmd=""
-    if test $KAIROS_FAMILY == "rhel" -o test $ID == "opensuse-tumbleweed"; then
+    if test $KAIROS_FAMILY == "rhel" -o test $ID == "opensuse-tumbleweed" -o test $ID == "opensuse-leap"; then
         set baseSelinuxCmd="selinux=0"
     else
         # if not in recovery


### PR DESCRIPTION
Seems like on 15.6 selinux is really enforced heavily and k3s wont start working unless the k3s selinux policies are added to base images