### PR TITLE
use values version for the proper version build

### DIFF
--- a/packages/utils/kubectl/build.yaml
+++ b/packages/utils/kubectl/build.yaml
@@ -5,7 +5,7 @@ requires:
 
 package_dir: /kubectl
 env:
-  - PACKAGE_VERSION={{ .Values.tag }}
+  - PACKAGE_VERSION={{ .Values.version }}
 
 steps:
 - mkdir -p /kubectl/usr/bin

--- a/packages/utils/kubectl/definition.yaml
+++ b/packages/utils/kubectl/definition.yaml
@@ -1,7 +1,6 @@
 name: kubectl
 category: container
-version: "1.30.2"
-tag: "1.29.1"
+version: "1.30.2+1"
 arch: "amd64"
 labels:
   github.repo: "kubectl"


### PR DESCRIPTION
otherwise we are using an old version with a newer package tag, which is wrong