### PR TITLE
Enable memory cgroups in rpi

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.39"
+    version: "1.1.40"

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -29,7 +29,8 @@ function setExtraArgs {
     set baseExtraArgs=""
     # rpi
     if test $KAIROS_MODEL == "rpi3" -o test $KAIROS_MODEL == "rpi4"; then
-        set baseExtraArgs="modprobe.blacklist=vc4 8250.nr_uarts=1"
+        # on rpi we need to enable memory cgroup for docker/k3s to work
+        set baseExtraArgs="modprobe.blacklist=vc4 8250.nr_uarts=1 cgroup_enable=memory"
     fi
 }
 


### PR DESCRIPTION
Otherwise k3s migth not work. Seems like most of the kernels have this enabled by default but on alpine we found out its not

Fixes https://github.com/kairos-io/kairos/issues/2002