### PR TITLE
Drop ukify package and rebuild systemd-boot one

### DIFF
--- a/packages/system/systemd/build.yaml
+++ b/packages/system/systemd/build.yaml
@@ -1,65 +1,24 @@
 package_dir: /package
 
-{{if eq .Values.name "systemd-boot"}}
-image: fedora:39
-prelude:
-    - dnf install -y systemd-boot
-steps:
-  # Artifacts located at src/systemd/build/src/boot/efi/
-  # change the x64 to aa64 for arm64
-  - mkdir -p /package/usr/kairos/
-    {{ if .Values.arch }}
-    {{ if eq .Values.arch "arm64" }}
-  - cp /usr/lib/systemd/boot/efi/systemd-bootaa64.efi /package/usr/kairos/
-  - cp /usr/lib/systemd/boot/efi/linuxaa64.efi.stub /package/usr/kairos/
-  - cp /usr/lib/systemd/boot/efi/addonaa64.efi.stub /package/usr/kairos/
-    {{else}}
-  - cp /usr/lib/systemd/boot/efi/systemd-bootx64.efi /package/usr/kairos/
-  - cp /usr/lib/systemd/boot/efi/linuxx64.efi.stub /package/usr/kairos/
-  - cp /usr/lib/systemd/boot/efi/addonx64.efi.stub /package/usr/kairos/
-    {{end}}
-{{end}}
-{{else if eq .Values.name "systemd-ukify"}}
-
-image: opensuse/leap:15.5
+image: fedora:40
 
 prelude:
-  - zypper ref && zypper in -y gcc13 git ninja gperf libpcap libpcap-devel libcap-devel cmake libmount-devel rsync diffutils openssl-devel tpm2-* python311-pip python311-cryptography
-  - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-  - mkdir -p src/
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cd src/ && git clone --branch v${PACKAGE_VERSION} https://github.com/systemd/systemd.git
+  - dnf install -y gcc git ninja-build meson diffutils gperf libcap-devel libmount-devel python3-jinja2 rsync libarchive-devel python3-pyelftools
+  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && git clone --branch v${PACKAGE_VERSION} https://github.com/systemd/systemd.git
 
 steps:
   # Minimal systemd build, remove almost everything, we only interested in the efi boot files
-  # To get systemd-measure to build we need to set blkid, openssl and bootloader to true (-Dbootloader=true -Defi=true -Dblkid=true -Dopenssl=true)
-  # To builod ukify we need to set -Dukify=true
-  # Set also the shared lib name with an appended kairos so we can use it everywhere without overwriting the system one (shared-lib-tag)
-  # Set the sbat values to kairos in case we want to use them in the future (-Dsbat-distro="Kairos" -Dsbat-distro-url="kairos.io" -Dsbat-distro-summary="Kairos" -Dsbat-distro-version="kairos-${PACKAGE_VERSION}")
-  # install meson ninja2 pefile pyelftools with pip as there is no package available in leap 15.5
-  # use a requirements.txt file to install the needed python packages specific versions  so we can reuse it on the osbuilder
-  - pip3 install -r ukify-requirements.txt
-  # install dev tools
-  - pip3 install meson ninja2
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cd src/systemd && env CC=gcc-13 meson setup build -Dmode=release -Dbootloader=true -Defi=true -Dukify=true -Dblkid=true -Dopenssl=true -Dshared-lib-tag=${PACKAGE_VERSION}-kairos -Dsbat-distro="Kairos" -Dsbat-distro-url="kairos.io" -Dsbat-distro-summary="Kairos" -Dsbat-distro-version="kairos-${PACKAGE_VERSION}" -Ddns-servers='' -Dsysvinit-path= -Dsysvrcnd-path= -Dtpm=false -Dinstall-tests=false -Dnss-resolve=disabled -Dlogind=false -Dcoredump=false -Dhomed=disabled -Dfirstboot=false -Dhostnamed=false -Dhibernate=false -Dinitrd=false -Dimportd=false -Dkernel-install=false -Dlocaled=false -Dmachined=false -Dnetworkd=false -Dnss-myhostname=false -Dnss-mymachines=false -Dnss-systemd=false -Doomd=false -Dportabled=false -Dhwdb=false -Dpstore=false -Dquotacheck=false -Drandomseed=false -Drepart=false -Dresolve=false -Drfkill=false -Dsysext=false -Danalyze=false -Dsysupdate=false -Dsysusers=false -Dstoragetm=false -Dtimedated=false -Dtimesyncd=false -Dtmpfiles=false -Duserdb=false -Dvconsole=false -Dxdg-autostart=false -Didn=false -Dpolkit=false -Dnscd=false -Dkmod=false -Ddbus=false -Dglib=false -Dbacklight=false -Dldconfig=false -Dgshadow=false -Dwheel-group=false -Dadm-group=false -Dxkbcommon=false -Dzstd=false -Dlz4=false -Dutmp=false -Dlink-udev-shared=false -Dlink-systemctl-shared=false -Dlink-networkd-shared=false -Dlink-timesyncd-shared=false -Dlink-journalctl-shared=false -Dlink-boot-shared=false -Dlink-portabled-shared=false -Denvironment-d=false -Dqrencode=false -Dpwquality=false -Dlibcurl=false -Dfdisk=false -Dlibidn2=false -Dlibiptc=false -Ddns-over-tls=false -Didn=false -Dgnutls=false -Dp11kit=false -Dlibidn=false -Dlibidn2=false -Dgcrypt=false -Dxz=false -Dzlib=false -Dbzip2=false
-  - cd src/systemd && ninja -C build
+  - cd systemd && meson setup build -Dmode=release -Dbootloader=enabled -Defi=true -Dukify=disabled -Dblkid=disabled -Dopenssl=disabled -Dsbat-distro="Kairos" -Dsbat-distro-url="kairos.io" -Dsbat-distro-summary="Kairos" -Dsbat-distro-version="kairos-${PACKAGE_VERSION}" -Ddns-servers='' -Dsysvinit-path= -Dsysvrcnd-path= -Dtpm=false -Dinstall-tests=false -Dnss-resolve=disabled -Dlogind=false -Dcoredump=false -Dhomed=disabled -Dfirstboot=false -Dhostnamed=false -Dhibernate=false -Dinitrd=false -Dimportd=disabled -Dkernel-install=false -Dlocaled=false -Dmachined=false -Dnetworkd=false -Dnss-myhostname=false -Dnss-mymachines=disabled -Dnss-systemd=false -Doomd=false -Dportabled=false -Dhwdb=false -Dpstore=false -Dquotacheck=false -Drandomseed=false -Drepart=disabled -Dresolve=false -Drfkill=false -Dsysext=false -Danalyze=false -Dsysupdate=disabled -Dsysusers=false -Dstoragetm=false -Dtimedated=false -Dtimesyncd=false -Dtmpfiles=false -Duserdb=false -Dvconsole=false -Dxdg-autostart=false -Didn=false -Dpolkit=disabled -Dnscd=false -Dkmod=disabled -Ddbus=disabled -Dglib=disabled -Dbacklight=false -Dldconfig=false -Dgshadow=false -Dwheel-group=false -Dadm-group=false -Dxkbcommon=disabled -Dzstd=disabled -Dlz4=disabled -Dutmp=false -Dlink-udev-shared=false -Dlink-systemctl-shared=false -Dlink-networkd-shared=false -Dlink-timesyncd-shared=false -Dlink-journalctl-shared=false -Dlink-boot-shared=false -Dlink-portabled-shared=false -Denvironment-d=false -Dqrencode=disabled -Dpwquality=disabled -Dlibcurl=disabled -Dfdisk=disabled -Dlibidn2=disabled -Dlibiptc=disabled -Ddns-over-tls=false -Didn=false -Dgnutls=disabled -Dp11kit=disabled -Dlibidn=disabled -Dlibidn2=disabled -Dgcrypt=disabled -Dxz=disabled -Dzlib=disabled -Dbzip2=disabled
+  - cd systemd && ninja -C build
   - mkdir -p /package/usr/kairos/
-  - mkdir -p /package/usr/lib/systemd/
-  - mkdir -p /package/usr/lib64/systemd/
-  - mkdir -p /package/lib64
-  - mkdir -p /package/lib
-  - mkdir -p /package/usr/bin/
-  # ukify calls systemd-measure to measure and sign
-  - cp src/systemd/build/systemd-measure /package/usr/lib/systemd/
-  - cp src/systemd/build/systemd-measure /package/usr/lib64/systemd/
-  - cp src/systemd/build/systemd-measure /package/lib/
-  - cp src/systemd/build/systemd-measure /package/lib64/
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cp src/systemd/build/src/shared/libsystemd-shared-${PACKAGE_VERSION}-kairos.so /package/usr/lib/systemd/
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cp src/systemd/build/src/shared/libsystemd-shared-${PACKAGE_VERSION}-kairos.so /package/usr/lib64/systemd/
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cp src/systemd/build/src/shared/libsystemd-shared-${PACKAGE_VERSION}-kairos.so /package/lib/
-  - PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && cp src/systemd/build/src/shared/libsystemd-shared-${PACKAGE_VERSION}-kairos.so /package/lib64/
-  # ukify is copied in two places according to upstream, I guess to maintain backwards compatibility
-  - src/systemd/build/ukify --version
-  - cp src/systemd/build/ukify /package/usr/bin/
-  - cp src/systemd/build/ukify /package/usr/lib/systemd/
-  - cp ukify-requirements.txt /package/usr/kairos/ukify-requirements.txt
-{{end}}
+    {{ if .Values.arch }}
+      {{ if eq .Values.arch "arm64" }}
+  - cp systemd/build/src/boot/efi/systemd-bootaa64.efi /package/usr/kairos/
+  - cp systemd/build/src/boot/efi/linuxaa64.efi.stub /package/usr/kairos/
+  - cp systemd/build/src/boot/efi/addonaa64.efi.stub /package/usr/kairos/
+      {{else}}
+  - cp systemd/build/src/boot/efi/systemd-bootx64.efi /package/usr/kairos/
+  - cp systemd/build/src/boot/efi/linuxx64.efi.stub /package/usr/kairos/
+  - cp systemd/build/src/boot/efi/addonx64.efi.stub /package/usr/kairos/
+      {{end}}
+    {{end}}

--- a/packages/system/systemd/collection.yaml
+++ b/packages/system/systemd/collection.yaml
@@ -1,15 +1,7 @@
 packages:
   - name: "systemd-boot"
     category: "system"
-    version: "256.2"
-    labels:
-      github.repo: "systemd"
-      autobump.revdeps: "true"
-      github.owner: "systemd"
-      autobump.skip_if_contains: '["rc"]'
-  - name: "systemd-ukify"
-    category: "system"
-    version: "255-5"
+    version: "256.2-1"
     labels:
       github.repo: "systemd"
       autobump.revdeps: "true"

--- a/packages/system/systemd/ukify-requirements.txt
+++ b/packages/system/systemd/ukify-requirements.txt
@@ -1,5 +1,0 @@
-cffi==1.15.1
-cryptography==41.0.7
-pefile==2023.2.7
-pycparser==2.21
-pyelftools==0.30


### PR DESCRIPTION
We were not really building the systemd-boot package ourselves but using the os artifacts.
That makes no sense, we want to track the exact version we are using so this patch changes it so we build systemd-boot ourselves at the given upstream version

Fixes https://github.com/kairos-io/kairos/issues/2632