### PR TITLE
set kairos services to simple

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.41"
+    version: "1.1.42"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=kairos interactive-installer
-After=sysinit.target
+After=multi-user.target
 [Service]
+## Dont mark it as running until it finishes
 Type=oneshot
 # input/output to tty as its interactive
 # otherwise it will be silent and with no input
@@ -17,5 +18,7 @@ ExecStart=/usr/bin/kairos-agent interactive-install --shell
 # Start systemd messages on tty
 ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
+# Restart if it fails, like user doing control+c
+Restart=on-failure
 [Install]
 WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=kairos recovery
-After=sysinit.target
+After=multi-user.target
 [Service]
-Type=oneshot
+Type=simple
 StandardInput=tty
 StandardOutput=tty
 LimitNOFILE=49152

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=kairos installer
-After=sysinit.target
+After=multi-user.target
 [Service]
-Type=oneshot
+Type=simple
 StandardInput=tty
 StandardOutput=tty
 LimitNOFILE=49152


### PR DESCRIPTION
If they are of type oneshot, systemd will wait until the pid exits before markling the service as running. Instead it will mark them as starting which is wrong and on livecd it causes the systemctl status output to be on starting forever.

Instead lets set those services to simple, which means they will be marked as started once the binary has been launched.

reset makes sense to have them like that as we dont want anything else to continue, but our reset and reboot after that.

Fixes https://github.com/kairos-io/kairos/issues/2665