### PR TITLE
Generate profile config instead of having a static file

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.42"
+    version: "1.1.43"

--- a/packages/static/kairos-overlay-files/files/etc/bash.bashrc.local
+++ b/packages/static/kairos-overlay-files/files/etc/bash.bashrc.local
@@ -1,5 +1,0 @@
-if [ -z "$KUBECONFIG" ]; then
-    if [ -e /etc/rancher/k3s/k3s.yaml ]; then
-        export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
-    fi
-fi

--- a/packages/static/kairos-overlay-files/files/system/oem/32_profile.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/32_profile.yaml
@@ -1,0 +1,15 @@
+name: "Profile extensions"
+stages:
+  initramfs:
+    - name: "Set KUBECONFIG to access k9s and kubectl"
+      files:
+        - path: /etc/profile.d/kairos.sh
+          permissions: 0644
+          owner: 0
+          group: 0
+          content: |
+            if [ -z "$KUBECONFIG" ]; then
+                if [ -e /etc/rancher/k3s/k3s.yaml ]; then
+                    export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+                fi
+            fi


### PR DESCRIPTION
The file `/etc/bash.bashrc.local` is only read by SUSE, the other distros (including SUSE) prefer a file under `/etc/profile.d/`. It's also generating the file instead of having it static in case one of the distros needs it differently then we can use flow control