### PR TITLE
Protect against first boot shenanigans

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.43"
+    version: "1.1.44"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-agent.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-agent.service
@@ -6,5 +6,3 @@ Wants=network.target
 Restart=on-failure
 RestartSec=5s
 ExecStart=/usr/bin/kairos-agent start
-[Install]
-WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-interactive.service
@@ -20,5 +20,3 @@ ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
 # Restart if it fails, like user doing control+c
 Restart=on-failure
-[Install]
-WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -15,5 +15,3 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent recovery
 # Start systemd messages on tty
 ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
-[Install]
-WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-reset.service
@@ -14,5 +14,3 @@ ExecStart=/usr/bin/kairos-agent reset --unattended --reboot
 # Start systemd messages on tty
 ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
-[Install]
-WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-webui.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-webui.service
@@ -4,5 +4,3 @@ After=sysinit.target
 [Service]
 ExecStart=/usr/bin/kairos-agent webui
 TimeoutStopSec=10s
-[Install]
-WantedBy=multi-user.target

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos.service
@@ -15,5 +15,3 @@ ExecStart=/usr/bin/kairos-agent install
 # Start systemd messages on tty
 ExecStartPost=-/usr/bin/kill -SIGRTMIN+20 1
 TimeoutStopSec=10s
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
Remove install section from our services. we dont install them, we just enable them manually so we dont really need to have an install section