### PR TITLE
Disable selinux for all flavors

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.46"
+    version: "1.1.47"

--- a/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
+++ b/packages/static/kairos-overlay-files/files/etc/cos/bootargs.cfg
@@ -1,14 +1,18 @@
 function setSelinux {
     source (loop0)/etc/os-release
-    set baseSelinuxCmd=""
-    if test $KAIROS_FAMILY == "rhel" -o test $ID == "opensuse-tumbleweed" -o test $ID == "opensuse-leap"; then
-        set baseSelinuxCmd="selinux=0"
-    else
-        # if not in recovery
-        if [ -z "$recoverylabel" ];then
-            set baseSelinuxCmd="security=selinux selinux=1"
-        fi
-    fi
+
+    # Disable selinux for all distros. Supporting selinux requires more than
+    # just enabling it like this.
+    set baseSelinuxCmd="selinux=0"
+
+    #if test $KAIROS_FAMILY == "rhel" -o test $ID == "opensuse-tumbleweed" -o test $ID == "opensuse-leap"; then
+    #    set baseSelinuxCmd="selinux=0"
+    #else
+    #    # if not in recovery
+    #    if [ -z "$recoverylabel" ];then
+    #        set baseSelinuxCmd="security=selinux selinux=1"
+    #    fi
+    #fi
 }
 
 function setExtraConsole {

--- a/packages/static/kairos-overlay-files/files/system/oem/26_selinux.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/26_selinux.yaml
@@ -4,6 +4,10 @@ stages:
     - name: "Relabelling"
       if: |
           cat /proc/cmdline | grep "selinux=1"
+      # NOTE: restorecon below is labeling all the files recursively, which may
+      # delay booting significantly (we had users reporting 30-minute delays)
+      # When we support selinux, consider whether we need to run it on every boot
+      # or not.
       commands:
         - |
           load_policy -i


### PR DESCRIPTION
because in order to support selinux, we need to do more than just enable it in the cmdline.

Fixes https://github.com/kairos-io/kairos/issues/2802