### PR TITLE
Increase UDP buffer sizes

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.52"
+    version: "1.1.53"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service
@@ -7,7 +7,9 @@ StandardInput=tty
 StandardOutput=tty
 LimitNOFILE=49152
 ExecStartPre=-/bin/sh -c "dmesg -D"
-ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=2500000"
+# This source explains why we are using this number
+# https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes/a3327deff89d2428d48596ce0e643531f9944f99
+ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=7500000"
 # Stop systemd messages on tty
 ExecStartPre=-/usr/bin/kill -SIGRTMIN+21 1
 TTYPath=/dev/tty1

--- a/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
@@ -7,7 +7,9 @@ stages:
   boot:
     - name: "Default sysctl settings"
       sysctl:
-        net.core.rmem_max: 2500000
+	# This source explains why we are using this number
+	# https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes/a3327deff89d2428d48596ce0e643531f9944f99
+        net.core.rmem_max: 7500000
         vm.max_map_count: 262144
         fs.inotify.max_user_instances: 8192
         fs.inotify.max_user_watches: 524288

--- a/packages/utils/edgevpn-systemd/definition.yaml
+++ b/packages/utils/edgevpn-systemd/definition.yaml
@@ -1,6 +1,6 @@
 name: edgevpn
 category: systemd-service
-version: "20211216"
+version: "20240830"
 requires:
 - name: edgevpn
   category: utils

--- a/packages/utils/edgevpn-systemd/edgevpn.service
+++ b/packages/utils/edgevpn-systemd/edgevpn.service
@@ -5,7 +5,8 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/systemd/system.conf.d/edgevpn.env
 LimitNOFILE=49152
-ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=2500000"
+ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=7500000"
+ExecStartPre=-/bin/sh -c "sysctl -w net.core.wmem_max=7500000"
 ExecStart=/usr/bin/edgevpn
 Restart=always
 

--- a/packages/utils/edgevpn-systemd/edgevpn.service
+++ b/packages/utils/edgevpn-systemd/edgevpn.service
@@ -5,6 +5,8 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/systemd/system.conf.d/edgevpn.env
 LimitNOFILE=49152
+# This source explains why we are using this number
+# https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes/a3327deff89d2428d48596ce0e643531f9944f99
 ExecStartPre=-/bin/sh -c "sysctl -w net.core.rmem_max=7500000"
 ExecStartPre=-/bin/sh -c "sysctl -w net.core.wmem_max=7500000"
 ExecStart=/usr/bin/edgevpn


### PR DESCRIPTION
The new size is 7.5M as recommended by quic-go [1] which previously was 2.5M [2]

[1]: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes/a3327deff89d2428d48596ce0e643531f9944f99
[2]: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes/597639d834d5d6c242d37d49a02ed04ca65332c9

Also I'm not sure if these should also be increased, or removed, or kept as they are. For edgevpn it is needed, but why for the rest?

https://github.com/kairos-io/packages/blob/9a729607cf29ae8036e2e377e4676cfbaa9fd5cf/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml#L10

https://github.com/kairos-io/packages/blob/9a729607cf29ae8036e2e377e4676cfbaa9fd5cf/packages/static/kairos-overlay-files/files/etc/systemd/system/kairos-recovery.service#L10