### PR TITLE
Create a sentinel file to avoid running the fix every time

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.47"
+    version: "1.1.48"

--- a/packages/static/kairos-overlay-files/files/system/oem/00_home_dir_owner_fix.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_home_dir_owner_fix.yaml
@@ -2,6 +2,7 @@ name: "Fix home directory permissions (kairos issue #2797)"
 stages:
   initramfs.after:
     - name: "Fix permissions"
+      if: '[ ! -f "/usr/local/.kairos/skip-home-directory-ownership-fix" ]'
       commands:
         - |
           # Iterate over users in /etc/passwd and chown their directories
@@ -13,3 +14,4 @@ stages:
                   echo "Directory $homedir does not exist for user $user"
               fi
           done
+          echo "https://github.com/kairos-io/kairos/issues/2843" > /usr/local/.kairos/skip-home-directory-ownership-fix


### PR DESCRIPTION
This file can also be created by the user to skip this fix if they so desire. For example, they may have files owned by some other user and they don't want to mess it up. In that case they can run a similar script themselves, but with additional logic.

Fixes https://github.com/kairos-io/kairos/issues/2843