### PR TITLE
Add override for the tpm2 service

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.49"
+    version: "1.1.50"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/tpm2-abrmd.service.d/override.conf
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/tpm2-abrmd.service.d/override.conf
@@ -1,0 +1,6 @@
+# Don't wait for 90 seconds for tpm devices when they don't exist
+[Service]
+TimeoutSec=5
+
+[Unit]
+JobTimeoutSec=5


### PR DESCRIPTION
to avoid waiting for 90 seconds for the tpm device to appear when there is not tpm device

Fixes https://github.com/kairos-io/kairos/issues/2835