### PR TITLE
Add `#cloud-config` header to all overlay files

### DIFF
--- a/packages/static/kairos-overlay-files/files/system/oem/00_datasource.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_datasource.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Datasource handling"
 stages:
   rootfs.before:

--- a/packages/static/kairos-overlay-files/files/system/oem/00_home_dir_owner_fix.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_home_dir_owner_fix.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Fix home directory permissions (kairos issue #2797)"
 stages:
   network.after:

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 # Rootfs Kairos OEM configuration file
 #
 # This file is part of Kairos and will get reset during upgrades.

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 # Rootfs Kairos OEM configuration file
 #
 # This file is part of Kairos and will get reset during upgrades.

--- a/packages/static/kairos-overlay-files/files/system/oem/02_agent.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/02_agent.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Start agent"
 stages:
   boot:

--- a/packages/static/kairos-overlay-files/files/system/oem/02_notify.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/02_notify.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Notify Kairos Plugins of Elemental Events"
 stages:
     initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/03-setupcon.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/03-setupcon.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Fonts fix for ubuntu"
 stages:
   initramfs.after:

--- a/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/05_network.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Default network configuration"
 stages:
   rootfs.before:

--- a/packages/static/kairos-overlay-files/files/system/oem/08_grub.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/08_grub.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 # Rootfs Kairos OEM configuration file
 #
 # This file is part of Kairos and will get reset during upgrades.

--- a/packages/static/kairos-overlay-files/files/system/oem/09_openrc_services.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/09_openrc_services.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Create openrc services"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/09_systemd_services.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 # Rootfs Kairos OEM configuration file
 #
 # This file is part of Kairos and will get reset during upgrades.

--- a/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
@@ -1,3 +1,5 @@
+# cloud-config
+
 name: "Default user, permissions and serial login"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
@@ -1,4 +1,5 @@
 #cloud-config
+
 name: "RPI configs"
 stages:
   initramfs.before:

--- a/packages/static/kairos-overlay-files/files/system/oem/12_nvidia.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/12_nvidia.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Nvidia jetson specific files"
 stages:
     initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/21_kcrypt.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/21_kcrypt.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Kcrypt"
 stages:
   after-upgrade:

--- a/packages/static/kairos-overlay-files/files/system/oem/23_c3os.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/23_c3os.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "c3os sentinel migration"
 stages:
   fs.after:

--- a/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/25_autologin.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Root autologin"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/26_selinux.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/26_selinux.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "SELinux"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/26_vm.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/26_vm.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Enable QEMU tools"
 stages:
   boot:

--- a/packages/static/kairos-overlay-files/files/system/oem/29_blacklist.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/29_blacklist.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 stages:
   initramfs.before:
     - name: "Blacklist bpfilter on Alpine ( bug: https://github.com/kairos-io/kairos/issues/277 )"

--- a/packages/static/kairos-overlay-files/files/system/oem/30_ulimit.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/30_ulimit.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 stages:
   boot.before:
     - name: "Setup higher limit for open files"

--- a/packages/static/kairos-overlay-files/files/system/oem/31_hosts.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/31_hosts.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 stages:
   initramfs.before:
     # For debian based distributions, /etc/hosts is present but empty. This is because the file

--- a/packages/static/kairos-overlay-files/files/system/oem/32_profile.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/32_profile.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Profile extensions"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/50_recovery.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Start recovery on tty1"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/51_reset.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Start reset on tty1"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/52_installer.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "Start installer on tty1"
 stages:
   initramfs:

--- a/packages/static/kairos-overlay-files/files/system/oem/99_sysext.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/99_sysext.yaml
@@ -1,3 +1,5 @@
+#cloud-config
+
 name: "sysext"
 stages:
   fs.after:


### PR DESCRIPTION
because `kairos-agent config` command ignores those files because of the missing header. That command is supposed to print all the config that is taken into account from kairos-agent and immucore and all.

Currently it ignore those files the same way it ignores them when running `kairos-agent manual-install` et al. Adding the header will make the kairos-agent respect those files, essentially with no effect since none of these files set any installation options.
The only useful result will be that `kairos-agent config` will print the full config making it easier for the user to see the full merged yaml that results from all the available config files.