### PR TITLE
Remove header from overlay file

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.50"
+    version: "1.1.51"

--- a/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
@@ -1,4 +1,3 @@
-#cloud-config
 name: "RPI configs"
 stages:
   initramfs.before:


### PR DESCRIPTION
for consistency (since the rest don't have one). We decided to remove this directory from the directories scanned by the kairos-agent anyway, so having a header or not should make no difference since yip doesn't care about the headers.

Part of: https://github.com/kairos-io/kairos/issues/2737