### PR TITLE
Add rpi kernel

### DIFF
--- a/packages/kernels/linux-rpi/build.yaml
+++ b/packages/kernels/linux-rpi/build.yaml
@@ -1,0 +1,17 @@
+package_dir: /out
+
+image: ubuntu:24.04
+
+prelude:
+  - apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu git make flex bc bison libssl-dev xz-utils kmod
+  - git clone --branch {{ .Values.version }} --depth 1 https://github.com/raspberrypi/linux.git linux
+
+steps:
+  - mkdir -p make /build
+  - mkdir -p /out/boot/overlays
+  - cd linux && CROSS_COMPILE=aarch64-linux-gnu- ARCH=arm64 make O=/build bcm2711_defconfig
+  - cd linux && CROSS_COMPILE=aarch64-linux-gnu- ARCH=arm64 make O=/build -j $(nproc) Image.gz modules dtbs
+  - cd linux && CROSS_COMPILE=aarch64-linux-gnu- ARCH=arm64 make O=/build INSTALL_MOD_PATH=/out modules_install
+  - cp /build/arch/arm64/boot/dts/broadcom/*.dtb /out/boot/
+  - cp /build/arch/arm64/boot/dts/overlays/*.dtb* /out/boot/overlays/
+  - cp /build/arch/arm64/boot/Image.gz /out/boot/Image

--- a/packages/kernels/linux-rpi/collection.yaml
+++ b/packages/kernels/linux-rpi/collection.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: "linux-rpi"
+    category: "kernels"
+    version: "rpi-6.6.y"
+    labels:
+      github.repo: "raspberrypi"
+      autobump.revdeps: "true"
+      github.owner: "kernel"
+      autobump.skip_if_contains: '["rc"]'


### PR DESCRIPTION
Builts from upstream directly. It would require changes to the arm builder scripts to identify the source as ubuntu and use this package instead, plus copy the /lib provided into the base image.

 - remove upstream kernel from base image
 - remove /lib/modules/* from base image
 - copy kernel to boot and links to to /boot/vmlinuz
 - copy package /lib into base image


supposedly that should make ubuntu boot back as the kernel has EFI enabled by default but no idea if it would actually work.

We could also split the package into modules+kernel and dtb files and overlay but I think its useless now.