### PR TITLE
Persistence for ETCD added

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.52"
+    version: "1.1.53"

--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.54"
+    version: "1.1.55"

--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.53"
+    version: "1.1.54"

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -42,6 +42,7 @@ stages:
           /var/lib/containerd
           /var/lib/calico
           /var/lib/dbus
+          /var/lib/etcd
           /var/lib/extensions
           /var/lib/kubelet
           /var/lib/longhorn

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
@@ -38,6 +38,7 @@ stages:
           /var/lib/cni
           /var/lib/containerd
           /var/lib/dbus
+          /var/lib/etcd
           /var/lib/extensions
           /var/lib/kubelet
           /var/lib/longhorn


### PR DESCRIPTION
This change is to add "/var/lib/etcd" path to the list of persistent paths.
This is required for kubeadm Kubernetes distributions to work.