### PR TITLE
Fix online status with more than one NIC

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.56"
+    version: "1.1.57"

--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.1.53"
+    version: "1.1.56"

--- a/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+++ b/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
@@ -1,4 +1,3 @@
 [Service]
 ExecStart=
 ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
-

--- a/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+++ b/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any --ipv4

--- a/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+++ b/static/kairos-overlay-files/files/etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
@@ -1,3 +1,4 @@
 [Service]
 ExecStart=
-ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any --ipv4
+ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
+


### PR DESCRIPTION
For systems with more than one unconfigured NIC, this allows the system to see any one interface online as enough to proceed with online status. Fixes [kairos:#2898](https://github.com/kairos-io/kairos/issues/2898) 