### PR TITLE
Implement `--recovery` flag in suc-upgrade script

### DIFF
--- a/packages/system/suc-upgrade/definition.yaml
+++ b/packages/system/suc-upgrade/definition.yaml
@@ -1,3 +1,3 @@
 name: "suc-upgrade"
 category: "system"
-version: "0.2.1"
+version: "0.2.2"

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -12,6 +12,18 @@ fi
 
 mount --rbind $HOST_DIR/dev /dev
 mount --rbind $HOST_DIR/run /run
-kairos-agent upgrade --source dir:/
+
+recovery_mode=false
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --recovery) recovery_mode=true;;
+    esac
+    shift
+done
+if [ "$recovery_mode" = true ]; then
+    kairos-agent upgrade --recovery --source dir:/
+else
+    kairos-agent upgrade --source dir:/
+fi
 nsenter -i -m -t 1 -- reboot
 exit 1


### PR DESCRIPTION
To allow users to upgrade recovery from kubernetes

Part of: https://github.com/kairos-io/kairos/issues/2760