### PR TITLE
Don't reboot when upgrading recovery through kubernetes

### DIFF
--- a/packages/system/suc-upgrade/definition.yaml
+++ b/packages/system/suc-upgrade/definition.yaml
@@ -1,3 +1,3 @@
 name: "suc-upgrade"
 category: "system"
-version: "0.2.2"
+version: "0.2.3"

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -22,8 +22,9 @@ while [[ "$#" -gt 0 ]]; do
 done
 if [ "$recovery_mode" = true ]; then
     kairos-agent upgrade --recovery --source dir:/
+    exit 0 # no need to reboot when upgrading recovery
 else
     kairos-agent upgrade --source dir:/
+    nsenter -i -m -t 1 -- reboot
+    exit 1
 fi
-nsenter -i -m -t 1 -- reboot
-exit 1


### PR DESCRIPTION
because it's not idempotent, the script never returns 0 and thus the upgrade is restarted after reboot, causing a boot loop.

As described here:

https://github.com/rancher/system-upgrade-controller/issues/23#issuecomment-583003758