### PR TITLE
Fix livecd user permissions for kairos

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.3.0"
+    version: "1.3.1"

--- a/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/10_accounting.yaml
@@ -13,6 +13,8 @@ stages:
       users:
         kairos:
           passwd: "kairos"
+          groups:
+            - "admin"
     - name: "Setup sudo"
       files:
       - path: "/etc/sudoers"


### PR DESCRIPTION
Otherwise if we dont add it to the sudo group, we cannot run stuff with sudo