### PR TITLE
Drop duplicated step

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.3.2"
+    version: "1.3.3"

--- a/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/11_RPI.yaml
@@ -9,13 +9,3 @@ stages:
       if: '[ -f "/sbin/openrc" ] && [ -f "/proc/device-tree/model" ] && grep -i "Raspberry Pi" "/proc/device-tree/model"'
       commands:
         - date -s "2006-08-14 02:34:56-06:00"
-  rootfs.after:
-    # Automatically expand persistent partition on Raspberry Pi 4
-    - if: '[ ! -f /run/cos/recovery_mode ] && [ ! -f /run/cos/live_mode ] && [ -f "/sys/firmware/devicetree/base/model" ] && grep -i "Raspberry Pi 4" "/sys/firmware/devicetree/base/model"'
-      name: "Grow persistent"
-      layout:
-        device:
-          label: COS_PERSISTENT
-        expand_partition:
-          # Size 0 is required to specify all remaining space
-          size: 0


### PR DESCRIPTION
Expansion of COS_PERSISTENT is already done on the rootfs yaml for all boots except livecd and recovery