### PR TITLE
Fix upgrade between 3.2.2 versions and older

### DIFF
--- a/packages/system/suc-upgrade/build.yaml
+++ b/packages/system/suc-upgrade/build.yaml
@@ -2,3 +2,5 @@ image: "alpine"
 
 steps:
 - cp -rfv suc-upgrade.sh /usr/sbin/suc-upgrade && chmod +x /usr/sbin/suc-upgrade
+# set the SUC_VERSION key in the script to the package version
+- sed -i "s/SUC_VERSION=.*/SUC_VERSION=${PACKAGE_VERSION}/" /usr/sbin/suc-upgrade

--- a/packages/system/suc-upgrade/definition.yaml
+++ b/packages/system/suc-upgrade/definition.yaml
@@ -1,3 +1,3 @@
 name: "suc-upgrade"
 category: "system"
-version: "0.3.0"
+version: "0.3.1"

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x -e
 HOST_DIR="${HOST_DIR:-/host}"
+SUC_VERSION="0.0.0"
+
+echo "SUC_VERSION: $SUC_VERSION"
 
 if [ "$FORCE" != "true" ]; then
     if [ -f "/etc/kairos-release" ]; then
@@ -11,7 +14,7 @@ if [ "$FORCE" != "true" ]; then
       UPDATE_VERSION=$(source /etc/os-release && echo "${KAIROS_VERSION}")
     fi
 
-    if [ -f "/etc/kairos-release" ]; then
+    if [ -f "${HOST_DIR}/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
       CURRENT_VERSION=$(source "${HOST_DIR}"/etc/kairos-release && echo "${KAIROS_VERSION}")
     else


### PR DESCRIPTION
We were checking the file in the container but we needed to check the file in the host system instead.

Also sets teh suc version and prints it at the script start for easy identification