### PR TITLE
Bump agent fips to newer version and bump fips toolchain

### DIFF
--- a/packages/system/kairos-agent/collection.yaml
+++ b/packages/system/kairos-agent/collection.yaml
@@ -12,7 +12,7 @@ packages:
     description: "Lifecycle agent for kairos"
   - name: "kairos-agent"
     category: "fips"
-    version: "2.15.3"
+    version: "2.15.4"
     labels:
       github.repo: "kairos-agent"
       autobump.revdeps: "true"

--- a/packages/toolchain-go/collection.yaml
+++ b/packages/toolchain-go/collection.yaml
@@ -68,8 +68,8 @@ packages:
   - name: toolchain-go
     category: fips
     variant: "alpine"
-    version: "1.23.1"
-    tag: "1.23.1"
+    version: "1.23.3"
+    tag: "1.23.3"
     hidden: true
   - name: toolchain-go-ubuntu
     category: fips
@@ -79,7 +79,7 @@ packages:
     hidden: true
   - name: toolchain-go-ubuntu
     category: fips
-    variant: "bullseye"
-    version: "1.23.1"
-    tag: "1.23.1"
+    variant: "bookworm"
+    version: "1.23.3"
+    tag: "1.23.3"
     hidden: true


### PR DESCRIPTION
Both the go version and the underelying OS need update