### PR TITLE
Make sure /etc/machine-id is generate as early as possible in systemd

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.6.1"
+    version: "1.6.2"

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -106,6 +106,13 @@ stages:
           /var/run/cilium
           /var/snap
         PERSISTENT_STATE_BIND: "true"
+    - if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
+      # Mask the commit service to avoid systemd messing with machine-id.
+      # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-commit.service.html
+      name: "Mask the commit service to avoid systemd messing with machine-id"
+      systemctl:
+        mask:
+          - systemd-machine-id-commit.service
   rootfs.after:
     - if: '[ -r /run/cos/custom-layout.env ] && [ ! -f "/run/cos/recovery_mode" ] && [ ! -f /run/cos/live_mode ]'
       name: "add custom bind and ephemeral mounts to /run/cos/cos-layout.env"
@@ -144,10 +151,7 @@ stages:
     - if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       name: "Ensure /etc/machine-id for systemd systems"
       commands:
-        # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-commit.service.html
         # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-setup.html
-        # Mask the commit service to avoid systemd messing with machine-id.
-        - ln -s /dev/null /etc/systemd/system/systemd-machine-id-commit.service
         - systemd-machine-id-setup
 
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -f "/sbin/openrc" ]'

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -140,8 +140,18 @@ stages:
       name: "Restore /etc/machine-id for systemd systems"
       commands:
         - cat /usr/local/etc/machine-id > /etc/machine-id
+    # If we didn't restore it already, ensure /etc/machine-id is generated
+    - if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
+      name: "Ensure /etc/machine-id for systemd systems"
+      commands:
+        # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-commit.service.html
+        # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-setup.html
+        # Mask the commit service to avoid systemd messing with machine-id.
+        - ln -s /dev/null /etc/systemd/system/systemd-machine-id-commit.service
+        - systemd-machine-id-setup
+
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -f "/sbin/openrc" ]'
-      name: "Restore /etc/machine-id for openrc systems"
+      name: "Ensure /etc/machine-id for openrc systems"
       commands:
         - dbus-uuidgen --ensure  # This makes sure that the machine-id exists and its valid
         - cat /var/lib/dbus/machine-id > /etc/machine-id


### PR DESCRIPTION
Fixes https://github.com/kairos-io/kairos/issues/303
Deprecates https://github.com/mudler/yip/pull/193