### PR TITLE
Bump package versions

### DIFF
--- a/packages/system/immucore/collection.yaml
+++ b/packages/system/immucore/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "immucore"
     category: "system"
-    version: "0.6.1"
+    version: "0.6.2"
     labels:
       github.repo: "immucore"
       autobump.revdeps: "true"
@@ -12,7 +12,7 @@ packages:
     description: "The Kairos immutability management interface"
   - name: "immucore"
     category: "fips"
-    version: "0.6.1"
+    version: "0.6.2"
     labels:
       github.repo: "immucore"
       autobump.revdeps: "true"

--- a/packages/system/kcrypt-challenger/collection.yaml
+++ b/packages/system/kcrypt-challenger/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - name: kcrypt-challenger
     binary_name: kcrypt-discovery-challenger
     category: system
-    version: "0.9.1"
+    version: "0.10.0"
     labels:
       github.repo: "kcrypt-challenger"
       github.owner: "kairos-io"
@@ -13,7 +13,7 @@ packages:
   - name: kcrypt-challenger
     binary_name: kcrypt-discovery-challenger
     category: fips
-    version: "0.9.1"
+    version: "0.10.0"
     labels:
       github.repo: "kcrypt-challenger"
       github.owner: "kairos-io"

--- a/packages/system/kcrypt/collection.yaml
+++ b/packages/system/kcrypt/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: kcrypt
     category: system
-    version: "0.12.2"
+    version: "0.13.0"
     labels:
       github.repo: "kcrypt"
       autobump.revdeps: "true"
@@ -12,7 +12,7 @@ packages:
     description: "Cloud native guardian for persistent data in the edge"
   - name: kcrypt
     category: fips
-    version: "0.12.2"
+    version: "0.13.0"
     labels:
       github.repo: "kcrypt"
       autobump.revdeps: "true"


### PR DESCRIPTION
Addressing [CVE-2024-45337](https://go.googlesource.com/crypto/+/refs/tags/v0.31.0) among other bumps