### PR TITLE
Introduce kairos.pull_datasources cmdline option to force pulling them

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.6.2"
+    version: "1.6.3"

--- a/packages/static/kairos-overlay-files/files/system/oem/00_datasource.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_datasource.yaml
@@ -2,7 +2,7 @@ name: "Datasource handling"
 stages:
   rootfs.before:
     - &datasource
-      if: '[ ! -f /oem/userdata ] && [ ! -f /run/cos/uki_boot_mode ]'
+      if: '[ ! -f /oem/userdata ] && ([ ! -f /run/cos/uki_boot_mode ] || grep -q "kairos.pull_datasources" /proc/cmdline )'
       name: "Pull data from provider"
       datasource:
         providers: ["cdrom", "gcp", "openstack", "aws", "azure", "hetzner", "packet", "vultr", "digitalocean", "metaldata", "vmware", "config-drive"]


### PR DESCRIPTION
Fixes https://github.com/kairos-io/kairos/issues/3032

If we merge this, it needs docs.