### PR TITLE
Add k0s Packages

### DIFF
--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -1,0 +1,42 @@
+requires:
+- name: "toolchain-go-ubuntu"
+  category: "development"
+  version: ">=0"
+env:
+  # Remove any possible "+N" from the end of the version. We only bump that to
+  # avoid overwritting existing images when we want the package to be rebuilt.
+  - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
+  {{$arch:=(default "amd64" .Values.arch)}}
+  {{ if eq $arch "arm" }}
+  - ARCH=arm64
+  {{ else }}
+  - ARCH={{ $arch }}
+  {{ end }}
+steps:
+  - c
+  # Let the installer script install service files for openrc or systemd:
+  # https://github.com/k3s-io/k3s/blob/36645e7311e9bdbbf2adb79ecd8bd68556bc86f6/install.sh#L114-L122
+  {{ if eq .Values.name "k0s-openrc" }}
+  - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
+  {{ else }}
+  - touch /bin/systemctl && chmod +x /bin/systemctl
+  - mkdir -p /etc/systemd/system/
+  {{ end }}
+  - bash installer.sh
+  - bash installer.sh agent
+  - rm -rf installer.sh
+  - chmod +x /usr/local/bin/k0s
+  - upx -1 /usr/local/bin/k0s
+
+includes:
+- ^/usr/local/bin/k0s
+{{ if eq .Values.name "k0s-openrc" }}
+- ^/etc/init.d/$
+- ^/etc/init.d/k0s*
+- ^/etc/k0s/$
+- ^/etc/k0s/k0s$
+{{ else }}
+- ^/etc/systemd$
+- ^/etc/systemd/system$
+- ^/etc/systemd/system/k0s*.service$
+{{ end }}

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -7,11 +7,12 @@ env:
 steps:
   - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
-  - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
+  # required by https://github.com/kardianos/service/blob/becf2eb62b83ed01f5e782cb8da7bb739ded2bb5/service_openrc_linux.go#L17
+  - touch /sbin/openrc-init && chmod +x /sbin/openrc-init
   {{ else }}
   -  apt-get update && apt-get install -y systemctl
   - mkdir -p /etc/systemd/system/
-  # force systemd service check by k0s installer
+  # required by https://github.com/kardianos/service/blob/becf2eb62b83ed01f5e782cb8da7bb739ded2bb5/service_systemd_linux.go#L23
   - mkdir -p /run/systemd/system
   {{ end }}
   - bash installer.sh

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -11,7 +11,7 @@ env:
   - ARCH={{ $arch }}
   {{ end }}
 steps:
-  - c
+  - curl -sfL https://get.k0s.io > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
   - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
   {{ else }}

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -1,10 +1,10 @@
-requires:
 {{ if eq .Values.name "k0s-openrc" }}
+image: "alpine"
+{{ else }}
+requires:
 - name: "toolchain-go-ubuntu"
   category: "development"
   version: ">=0"
-{{ else }}
-image: "alpine"
 {{ end }}
 env:
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
@@ -19,12 +19,13 @@ steps:
   - mkdir -p /run/systemd/system
   {{ end }}
   - curl -sfL https://get.k0s.sh > installer.sh
-  - bash installer.sh
+  - sh installer.sh
   - rm -rf installer.sh
   - k0s install controller --single --debug --verbose
   - chmod +x /usr/local/bin/k0s
   - upx -1 /usr/local/bin/k0s
   - mv /usr/local/bin/k0s /usr/bin/k0s
+  - ls -las /usr/bin/k0s
 
 includes:
 - ^/usr/bin/k0s

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -3,8 +3,6 @@ requires:
   category: "development"
   version: ">=0"
 env:
-  # Remove any possible "+N" from the end of the version. We only bump that to
-  # avoid overwritting existing images when we want the package to be rebuilt.
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
   {{$arch:=(default "amd64" .Values.arch)}}
   {{ if eq $arch "arm" }}
@@ -14,8 +12,6 @@ env:
   {{ end }}
 steps:
   - c
-  # Let the installer script install service files for openrc or systemd:
-  # https://github.com/k3s-io/k3s/blob/36645e7311e9bdbbf2adb79ecd8bd68556bc86f6/install.sh#L114-L122
   {{ if eq .Values.name "k0s-openrc" }}
   - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
   {{ else }}

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -11,7 +11,7 @@ env:
 steps:
   - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
-  - apk add openrc
+  - apk add openrc curl upx
   {{ else }}
   - apt-get update && apt-get install -y systemctl
   - mkdir -p /etc/systemd/system/

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -1,16 +1,19 @@
 requires:
+{{ if eq .Values.name "k0s-openrc" }}
 - name: "toolchain-go-ubuntu"
   category: "development"
   version: ">=0"
+{{ else }}
+image: "alpine"
+{{ end }}
 env:
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
 steps:
   - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
-  # required by https://github.com/kardianos/service/blob/becf2eb62b83ed01f5e782cb8da7bb739ded2bb5/service_openrc_linux.go#L17
-  - touch /sbin/openrc-init && chmod +x /sbin/openrc-init
+  - apk add openrc
   {{ else }}
-  -  apt-get update && apt-get install -y systemctl
+  - apt-get update && apt-get install -y systemctl
   - mkdir -p /etc/systemd/system/
   # required by https://github.com/kardianos/service/blob/becf2eb62b83ed01f5e782cb8da7bb739ded2bb5/service_systemd_linux.go#L23
   - mkdir -p /run/systemd/system

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -20,9 +20,10 @@ steps:
   - k0s install controller --single --debug --verbose
   - chmod +x /usr/local/bin/k0s
   - upx -1 /usr/local/bin/k0s
+  - mv /usr/local/bin/k0s /usr/bin/k0s
 
 includes:
-- ^/usr/local/bin/k0s
+- ^/usr/bin/k0s
 {{ if eq .Values.name "k0s-openrc" }}
 - ^/etc/init.d/$
 - ^/etc/init.d/k0s*

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -4,18 +4,12 @@ requires:
   version: ">=0"
 env:
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
-  {{$arch:=(default "amd64" .Values.arch)}}
-  {{ if eq $arch "arm" }}
-  - ARCH=arm64
-  {{ else }}
-  - ARCH={{ $arch }}
-  {{ end }}
 steps:
   - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
   - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
   {{ else }}
-  - touch /bin/systemctl && chmod +x /bin/systemctl
+  -  apt-get update && apt-get install -y systemctl
   - mkdir -p /etc/systemd/system/
   # force systemd service check by k0s installer
   - mkdir -p /run/systemd/system

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -11,7 +11,7 @@ env:
   - ARCH={{ $arch }}
   {{ end }}
 steps:
-  - curl -sfL https://get.k0s.io > installer.sh
+  - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
   - touch /sbin/openrc-run && chmod +x /sbin/openrc-run
   {{ else }}

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -9,7 +9,6 @@ image: "alpine"
 env:
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
 steps:
-  - curl -sfL https://get.k0s.sh > installer.sh
   {{ if eq .Values.name "k0s-openrc" }}
   - apk add openrc curl upx
   {{ else }}
@@ -18,6 +17,7 @@ steps:
   # required by https://github.com/kardianos/service/blob/becf2eb62b83ed01f5e782cb8da7bb739ded2bb5/service_systemd_linux.go#L23
   - mkdir -p /run/systemd/system
   {{ end }}
+  - curl -sfL https://get.k0s.sh > installer.sh
   - bash installer.sh
   - rm -rf installer.sh
   - k0s install controller --single --debug --verbose

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -17,10 +17,12 @@ steps:
   {{ else }}
   - touch /bin/systemctl && chmod +x /bin/systemctl
   - mkdir -p /etc/systemd/system/
+  # force systemd service check by k0s installer
+  - mkdir -p /run/systemd/system
   {{ end }}
   - bash installer.sh
-  - bash installer.sh agent
   - rm -rf installer.sh
+  - k0s install controller --single --debug --verbose
   - chmod +x /usr/local/bin/k0s
   - upx -1 /usr/local/bin/k0s
 

--- a/packages/k8s/k0s/build.yaml
+++ b/packages/k8s/k0s/build.yaml
@@ -10,6 +10,7 @@ env:
   - K0S_VERSION=v{{ regexReplaceAll "\\+\\d+$" .Values.version "" }}+k0s.{{.Values.k0s_version}}
 steps:
   {{ if eq .Values.name "k0s-openrc" }}
+  - apk update
   - apk add openrc curl upx
   {{ else }}
   - apt-get update && apt-get install -y systemctl

--- a/packages/k8s/k0s/collection.yaml
+++ b/packages/k8s/k0s/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - name: k0s-openrc
     category: k8s
     version: "1.31.3"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"
@@ -15,7 +15,7 @@ packages:
   - name: k0s-openrc
     category: k8s
     version: "1.30.7"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"
@@ -28,7 +28,7 @@ packages:
   - name: k0s-openrc
     category: k8s
     version: "1.29.11"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"
@@ -41,7 +41,7 @@ packages:
   - name: k0s-systemd
     category: k8s
     version: "1.31.3"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"
@@ -54,7 +54,7 @@ packages:
   - name: k0s-systemd
     category: k8s
     version: "1.30.7"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"
@@ -67,7 +67,7 @@ packages:
   - name: k0s-systemd
     category: k8s
     version: "1.29.11"
-    k3s_version: "0"
+    k0s_version: "0"
     labels:
       github.owner: "k0sproject"
       github.repo: "k0s"

--- a/packages/k8s/k0s/collection.yaml
+++ b/packages/k8s/k0s/collection.yaml
@@ -12,6 +12,32 @@ packages:
       - https://github.com/k0sproject/k0s
     license: "APL-2"
     description: " The Zero Friction Kubernetes "
+  - name: k0s-openrc
+    category: k8s
+    version: "1.30.7"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes "
+  - name: k0s-openrc
+    category: k8s
+    version: "1.29.11"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes "
   - name: k0s-systemd
     category: k8s
     version: "1.31.3"
@@ -24,4 +50,30 @@ packages:
     uri:
       - https://github.com/k0sproject/k0s
     license: "APL-2"
-    description: " The Zero Friction Kubernetes " 
+    description: " The Zero Friction Kubernetes "
+  - name: k0s-systemd
+    category: k8s
+    version: "1.30.7"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes "
+  - name: k0s-systemd
+    category: k8s
+    version: "1.29.11"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes "

--- a/packages/k8s/k0s/collection.yaml
+++ b/packages/k8s/k0s/collection.yaml
@@ -1,0 +1,27 @@
+packages:
+  - name: k0s-openrc
+    category: k8s
+    version: "1.31.3"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes "
+  - name: k0s-systemd
+    category: k8s
+    version: "1.31.3"
+    k3s_version: "0"
+    labels:
+      github.owner: "k0sproject"
+      github.repo: "k0s"
+      autobump.sed_script: 's/\+k0s.[0-9]//g'
+      autobump.skip_if_contains: '["k0s"]' # disable autobump
+    uri:
+      - https://github.com/k0sproject/k0s
+    license: "APL-2"
+    description: " The Zero Friction Kubernetes " 

--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.6.3"
+    version: "1.6.4"

--- a/packages/static/kairos-overlay-files/files/etc/systemd/system/k0scontroller.service.d/override.conf
+++ b/packages/static/kairos-overlay-files/files/etc/systemd/system/k0scontroller.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+ConditionFileIsExecutable=
+ConditionFileIsExecutable=/usr/bin/k0s
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/k0s controller --debug=true --single=true --verbose=true


### PR DESCRIPTION
This PR adds the creation of k0s packages for `openrc` and `systemd`.
It is explicitly targeting Kubernetes versions `1.31.3`, `1.30.7` and `1.29.11`.

Thanks for reviewing

fixes https://github.com/kairos-io/kairos/issues/3124