### PR TITLE
Add k0s paths to be persistent

### DIFF
--- a/packages/static/kairos-overlay-files/collection.yaml
+++ b/packages/static/kairos-overlay-files/collection.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: "kairos-overlay-files"
     category: "static"
-    version: "1.6.4"
+    version: "1.6.5"

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml
@@ -19,6 +19,7 @@ stages:
           /etc/cni
           /etc/init.d
           /etc/iscsi
+          /etc/k0s
           /etc/kubernetes
           /etc/modprobe.d
           /etc/pwx
@@ -44,6 +45,7 @@ stages:
           /var/lib/dbus
           /var/lib/etcd
           /var/lib/extensions
+          /var/lib/k0s
           /var/lib/kubelet
           /var/lib/longhorn
           /var/lib/osd
@@ -73,6 +75,7 @@ stages:
           /etc/cni
           /etc/init.d
           /etc/iscsi
+          /etc/k0s
           /etc/kubernetes
           /etc/modprobe.d
           /etc/pwx
@@ -94,6 +97,7 @@ stages:
           /var/lib/cni
           /var/lib/containerd
           /var/lib/calico
+          /var/lib/k0s
           /var/lib/kubelet
           /var/lib/longhorn
           /var/lib/osd

--- a/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
+++ b/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml
@@ -18,6 +18,7 @@ stages:
         PERSISTENT_STATE_PATHS: >-
           /etc/cni
           /etc/iscsi
+          /etc/k0s
           /etc/kubernetes
           /etc/modprobe.d
           /etc/rancher
@@ -40,6 +41,7 @@ stages:
           /var/lib/dbus
           /var/lib/etcd
           /var/lib/extensions
+          /var/lib/k0s
           /var/lib/kubelet
           /var/lib/longhorn
           /var/lib/rancher


### PR DESCRIPTION
otherwise you get the common issue with the overlay files

```
[  524.551119] overlay: filesystem on /var/lib/k0s/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/69/work not supported as upperdir
[  526.555574] overlay: filesystem on /var/lib/k0s/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/70/work not supported as upperdir
```