### PR TITLE
Fix artifacts package

### DIFF
--- a/packages/static/grub-artifacts/build.yaml
+++ b/packages/static/grub-artifacts/build.yaml
@@ -11,9 +11,9 @@ prelude:
 {{end}}
 
 steps:
-- mkdir /grub-artifacts
+- mkdir /grub-artifacts/grub2
 - mkdir -p /grub-artifacts/EFI/BOOT
-- cp -rf /usr/share/grub2/* /grub-artifacts
+- cp -rf /usr/share/grub2/* /grub-artifacts/grub2
 {{ if .Values.arch }}
   {{ if eq .Values.arch "arm64" }}
 - cp /usr/share/grub2/arm64-efi/grub.efi /grub-artifacts/EFI/BOOT/grub.efi

--- a/packages/static/grub-artifacts/definition.yaml
+++ b/packages/static/grub-artifacts/definition.yaml
@@ -1,5 +1,5 @@
 name: "grub-artifacts"
 category: "static"
-version: "0.3"
+version: "0.4.0"
 distribution: opensuse
 image: opensuse/tumbleweed


### PR DESCRIPTION
Put it where the efi files would expect the prefix to be at

That way when we dump this pacakge into an EFI partition, we have the correct dirs:

 - `/grub2/ARCH-efi/` -> modules and fonts and such
 - `/EFI/BOOT` -> efi files