### PR TITLE
Check software version too when deciding if to upgrade

### DIFF
--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -8,18 +8,18 @@ echo "SUC_VERSION: $SUC_VERSION"
 if [ "$FORCE" != "true" ]; then
     if [ -f "/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
-      UPDATE_VERSION=$(source /etc/kairos-release && echo "${KAIROS_VERSION}")
+      UPDATE_VERSION=$(source /etc/kairos-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}")
     else
       # shellcheck disable=SC1091
-      UPDATE_VERSION=$(source /etc/os-release && echo "${KAIROS_VERSION}")
+      UPDATE_VERSION=$(source /etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
     fi
 
     if [ -f "${HOST_DIR}/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/kairos-release && echo "${KAIROS_VERSION}")
+      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/kairos-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
     else
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/os-release && echo "${KAIROS_VERSION}")
+      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
     fi
 
     if [ "$CURRENT_VERSION" == "$UPDATE_VERSION" ]; then

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -11,15 +11,15 @@ if [ "$FORCE" != "true" ]; then
       UPDATE_VERSION=$(source /etc/kairos-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}")
     else
       # shellcheck disable=SC1091
-      UPDATE_VERSION=$(source /etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
+      UPDATE_VERSION=$(source /etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}")
     fi
 
     if [ -f "${HOST_DIR}/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/kairos-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
+      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/kairos-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}")
     else
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}"")
+      CURRENT_VERSION=$(source "${HOST_DIR}"/etc/os-release && echo "KAIROS_VERSION=${KAIROS_VERSION};KAIROS_SOFTWARE_VERSION=${KAIROS_SOFTWARE_VERSION}")
     fi
 
     if [ "$CURRENT_VERSION" == "$UPDATE_VERSION" ]; then


### PR DESCRIPTION


For older versions, this check was enough: KAIROS_VERSION="v3.3.6-v1.32.2-k3s1" to decide if upgrade is needed or not, because the version included k3s version too.

In the latest version, k3s version is not included and this check is not enough: KAIROS_VERSION="v3.4.0". 
KAIROS_SOFTWARE_VERSION="1.32.3+k3s1" has to be checked too, in case the same Kairos version is used, but different k3s version.

This should fix the case when upgrading from "12-standard-amd64-generic-v3.4.0-k3s1.30.11-k3s1" to "12-standard-amd64-generic-v3.4.0-k3s1.31.7-k3s1". Right now, it won't upgrade and it will report that the system is up to date.

This is how /etc/kairos-release looks like in the latest version:
![image](https://github.com/user-attachments/assets/31ae3ac1-0ec0-4a55-8120-0ad4ae639f39)

KAIROS_SOFTWARE_VERSION is the only piece of information regarding k3s version.


