### PR TITLE
Bump suc-provider to deal with newer versions

### DIFF
--- a/packages/system/suc-upgrade/definition.yaml
+++ b/packages/system/suc-upgrade/definition.yaml
@@ -1,3 +1,3 @@
 name: "suc-upgrade"
 category: "system"
-version: "0.3.1"
+version: "0.4.0"

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -22,9 +22,7 @@ get_update_version() {
             echo "$KAIROS_VERSION"
         else
             # if we have a provider, we return the version with the provider + the version
-            # Clean software version in case it has a leading v as we dont have that in the artifacts
-            KAIROS_SOFTWARE_VERSION="${KAIROS_SOFTWARE_VERSION#v}"
-            # Also replace any + with a - as we dont have that in the artifacts, not possible for oci artifacts
+            # Replace any + with a - as we dont have that in the artifacts, not possible for oci artifacts
             KAIROS_SOFTWARE_VERSION="${KAIROS_SOFTWARE_VERSION//+/\-}"
             echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}"
         fi

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -22,6 +22,10 @@ get_update_version() {
             echo "$KAIROS_VERSION"
         else
             # if we have a provider, we return the version with the provider + the version
+            # Clean software version in case it has a leading v as we dont have that in the artifacts
+            KAIROS_SOFTWARE_VERSION="${KAIROS_SOFTWARE_VERSION#v}"
+            # Also replace any + with a - as we dont have that in the artifacts, not possible for oci artifacts
+            KAIROS_SOFTWARE_VERSION="${KAIROS_SOFTWARE_VERSION//+/\-}"
             echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}"
         fi
     else

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -5,47 +5,20 @@ SUC_VERSION="0.0.0"
 
 echo "SUC_VERSION: $SUC_VERSION"
 
-version_ge() {
-    # Compare two semantic versions
-    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n 1)" = "$2" ]
-}
-
-# Get the update version from the release file
-get_update_version() {
-    local release_file="$1"
-    # shellcheck disable=SC1090
-    source "${release_file}"
-    # If we are on 3.4.0 or higher
-    if version_ge "$KAIROS_VERSION" "3.4.0"; then
-        # if we dont have any provider, we just return the version
-        if [ -z "$KAIROS_SOFTWARE_VERSION_PREFIX" ]; then
-            echo "$KAIROS_VERSION"
-        else
-            # if we have a provider, we return the version with the provider + the version
-            # Replace any + with a - as we dont have that in the artifacts, not possible for oci artifacts
-            KAIROS_SOFTWARE_VERSION="${KAIROS_SOFTWARE_VERSION//+/\-}"
-            echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}"
-        fi
-    else
-        # if we are on a version lower than 3.4.0, we just return the version as before
-        echo "$KAIROS_VERSION"
-    fi
-}
-
 if [ "$FORCE" != "true" ]; then
     if [ -f "/etc/kairos-release" ]; then
-      UPDATE_VERSION=$(get_update_version "/etc/kairos-release")
+      UPDATE_VERSION=$(source "/etc/kairos-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
     else
       # shellcheck disable=SC1091
-      UPDATE_VERSION=$(get_update_version "/etc/os-release")
+      UPDATE_VERSION=$(source "/etc/os-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
     fi
 
     if [ -f "${HOST_DIR}/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(get_update_version "${HOST_DIR}/etc/kairos-release")
+      CURRENT_VERSION=$(source "${HOST_DIR}/etc/kairos-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
     else
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(get_update_version "${HOST_DIR}/etc/os-release")
+      CURRENT_VERSION=$(source "${HOST_DIR}/etc/os-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
     fi
 
     if [ "$CURRENT_VERSION" == "$UPDATE_VERSION" ]; then

--- a/packages/system/suc-upgrade/suc-upgrade.sh
+++ b/packages/system/suc-upgrade/suc-upgrade.sh
@@ -5,20 +5,28 @@ SUC_VERSION="0.0.0"
 
 echo "SUC_VERSION: $SUC_VERSION"
 
+get_version() {
+    local file_path="$1"
+    # shellcheck disable=SC1090
+    source "$file_path"
+
+    echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}"
+}
+
 if [ "$FORCE" != "true" ]; then
     if [ -f "/etc/kairos-release" ]; then
-      UPDATE_VERSION=$(source "/etc/kairos-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
+      UPDATE_VERSION=$(get_version "/etc/kairos-release")
     else
       # shellcheck disable=SC1091
-      UPDATE_VERSION=$(source "/etc/os-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
+      UPDATE_VERSION=$(get_version "/etc/os-release" )
     fi
 
     if [ -f "${HOST_DIR}/etc/kairos-release" ]; then
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}/etc/kairos-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
+      CURRENT_VERSION=$(get_version "${HOST_DIR}/etc/kairos-release" )
     else
       # shellcheck disable=SC1091
-      CURRENT_VERSION=$(source "${HOST_DIR}/etc/os-release" && echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}")
+      CURRENT_VERSION=$(get_version "${HOST_DIR}/etc/os-release" )
     fi
 
     if [ "$CURRENT_VERSION" == "$UPDATE_VERSION" ]; then


### PR DESCRIPTION
This checks if we are on 3.4.0 as keys have changed, and if so, it checks the provider values. If empty it just returns the version normally, but if we have a provider version then it constructs the proper version wiht the provider name and version included on it in order to upgrade properly